### PR TITLE
DOC: fix example set_facts -> add_facts

### DIFF
--- a/docsrc/source/education/examples/reasoning.md
+++ b/docsrc/source/education/examples/reasoning.md
@@ -63,7 +63,7 @@ query = Exists(x, foursides(x), name='foursided_objects')
 model.add_formulae(square, rectangle, square_rect, rect_foursides, query)
      
 # Add facts to the model
-model.set_facts({'square': {'c': Fact.TRUE, 'k': Fact.TRUE}})
+model.add_facts({'square': {'c': Fact.TRUE, 'k': Fact.TRUE}})
      
 # Perform inference
 steps, facts_inferred = model.infer()


### PR DESCRIPTION
Hi,

There is incorrect name of `Model.set_facts()` method in [geometry reasoning example](https://ibm.github.io/LNN/education/examples/reasoning.html#simple-geometry-reasoning-example).

Should be fixed in my PR :)

TM