### PR TITLE
add **kwds to argument list of Not.upward

### DIFF
--- a/lnn/symbolic/logic.py
+++ b/lnn/symbolic/logic.py
@@ -1259,7 +1259,7 @@ class Not(_UnaryOperator):
         self.neuron = _NodeActivation()(
             self.propositional, self.world, **kwds.get('neuron', {}))
 
-    def upward(self) -> torch.Tensor:
+    def upward(self, **kwds) -> torch.Tensor:
         if self.propositional:
             groundings = {None}
         else:


### PR DESCRIPTION
When **kwds is not part of the argument list, the following error is thrown when training a network which contains a negation:
"TypeError: upward() got an unexpected keyword argument 'losses'"

This script generates this error in the original code:
https://drive.google.com/file/d/16mUagX7-zZw4iF8x972D6B-Ct9_l0cWB/view?usp=sharing

