### PR TITLE
PEP: imports

### DIFF
--- a/lnn/__init__.py
+++ b/lnn/__init__.py
@@ -13,6 +13,7 @@ from .utils import (truth_table, truth_table_dict, predicate_truth_table,
                     bool_to_fact)
 from .constants import Fact, World, Direction, Join
 
+
 # constants
 UPWARD = Direction.UPWARD
 DOWNWARD = Direction.DOWNWARD

--- a/lnn/_exceptions.py
+++ b/lnn/_exceptions.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from .constants import Fact, World, Direction
+from typing import Set, Tuple, Dict
 
 import torch
-from typing import Set, Tuple, Dict
+
+from .constants import Fact, World, Direction
 
 
 class AssertWorld:

--- a/lnn/_utils.py
+++ b/lnn/_utils.py
@@ -4,14 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from . import _exceptions
-from .constants import World, Fact, _Fact
-
 import time
+from typing import Union, TypeVar, Tuple
+
 import torch
 import torchviz
 import numpy as np
-from typing import Union, TypeVar, Tuple
+
+from . import _exceptions
+from .constants import World, Fact, _Fact
 
 
 class MultiInstance:

--- a/lnn/model.py
+++ b/lnn/model.py
@@ -4,18 +4,19 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import random
+import warnings
+from itertools import chain
+from typing import Union, Dict, Tuple
+
+import torch
+import networkx as nx
+from tqdm import tqdm
+
 from . import _utils, _exceptions
 from .symbolic.axioms import lifted_axioms
 from .constants import Fact, World, Direction
 from .symbolic.logic import Proposition, Predicate, _Formula
-
-import torch
-import random
-import warnings
-import networkx as nx
-from tqdm import tqdm
-from itertools import chain
-from typing import Union, Dict, Tuple
 
 
 class Model:

--- a/lnn/neural/__init__.py
+++ b/lnn/neural/__init__.py
@@ -5,4 +5,5 @@
 ##
 
 from .methods.lukasiewicz import Lukasiewicz
+
 __all__ = ['Lukasiewicz']

--- a/lnn/neural/activations/neuron/dynamic.py
+++ b/lnn/neural/activations/neuron/dynamic.py
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from .neuron import _NeuronActivation
 import torch
+
+from .neuron import _NeuronActivation
 
 
 class _DynamicActivation(_NeuronActivation):

--- a/lnn/neural/activations/neuron/neuron.py
+++ b/lnn/neural/activations/neuron/neuron.py
@@ -4,12 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import torch
+
 from ...._utils import val_clamp
 from ..node import _NodeActivation
 from ....constants import Direction
 from ...parameters.neuron import _NeuronParameters
 
-import torch
 
 """
 Dynamic activation function

--- a/lnn/neural/activations/neuron/static.py
+++ b/lnn/neural/activations/neuron/static.py
@@ -6,6 +6,7 @@
 
 from .neuron import _NeuronActivation
 
+
 """
 Static neuron activation function
 """

--- a/lnn/neural/activations/node.py
+++ b/lnn/neural/activations/node.py
@@ -4,12 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from ..._utils import val_clamp
-from ..parameters.node import _NodeParameters
+from typing import Tuple, List, Union
 
 import torch
 import numpy as np
-from typing import Tuple, List, Union
+
+from ..._utils import val_clamp
+from ..parameters.node import _NodeParameters
+
 
 """
 Node level activation

--- a/lnn/neural/methods/dynamiclinear.py
+++ b/lnn/neural/methods/dynamiclinear.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import torch
+
 from ...constants import Direction
 from ..._utils import negate_bounds as _not
 from ..activations.neuron.dynamic import _DynamicActivation
-import torch
 
 
 class DynamicLinear(_DynamicActivation):

--- a/lnn/neural/methods/lukasiewicztransparent.py
+++ b/lnn/neural/methods/lukasiewicztransparent.py
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import torch
+
 from ...constants import Direction
 from ..._utils import val_clamp, negate_bounds as _not
 from ..activations.neuron.static import _StaticActivation
-
-import torch
 
 
 class LukasiewiczTransparent(_StaticActivation):

--- a/lnn/neural/parameters/neuron.py
+++ b/lnn/neural/parameters/neuron.py
@@ -5,6 +5,7 @@
 ##
 
 import torch
+
 from ... import _exceptions
 from .node import _NodeParameters
 

--- a/lnn/neural/parameters/node.py
+++ b/lnn/neural/parameters/node.py
@@ -4,13 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import math
+from typing import Union, Optional, Tuple, Iterator, List, Dict, Set
+
+import torch
+
 from ... import _utils
 from ...constants import Fact, World
 from ... import _exceptions
-
-import torch
-import math
-from typing import Union, Optional, Tuple, Iterator, List, Dict, Set
 
 
 class _NodeParameters:

--- a/lnn/symbolic/__init__.py
+++ b/lnn/symbolic/__init__.py
@@ -1,6 +1,7 @@
 from .logic import (Proposition, Predicate, And, Or,
                     Implies, Bidirectional, Not, ForAll, Exists, Variable,
                     NeuralActivationClass)
+
 __all__ = ['Proposition', 'Predicate', 'And', 'Or',
            'Implies', 'Bidirectional', 'Not', 'ForAll', 'Exists', 'Variable',
            'NeuralActivationClass']

--- a/lnn/symbolic/_gm.py
+++ b/lnn/symbolic/_gm.py
@@ -4,13 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import copy
+from itertools import chain
+from typing import Tuple, Union, List, TypeVar, Set
+
+import torch
+
 from ..constants import Direction, Join
 from .._utils import negate_bounds
 
-import copy
-import torch
-from itertools import chain
-from typing import Tuple, Union, List, TypeVar, Set
 
 """
 Grounding management module

--- a/lnn/symbolic/axioms.py
+++ b/lnn/symbolic/axioms.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+from typing import Tuple
+
 from ..constants import World
 from ..symbolic import Implies
-from typing import Tuple
 
 
 def lifted_axioms() -> dict:

--- a/lnn/symbolic/logic.py
+++ b/lnn/symbolic/logic.py
@@ -4,15 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from . import _gm, _trace
-from .. import _utils, _exceptions, utils
-from ..constants import Fact, World, AutoName, Direction, Join
-
-import torch
-import numpy as np
 from enum import auto
 from importlib import import_module
 from typing import Optional, Union, Tuple, Iterator, Set, List, Dict, TypeVar
+
+import torch
+import numpy as np
+
+from . import _gm, _trace
+from .. import _utils, _exceptions, utils
+from ..constants import Fact, World, AutoName, Direction, Join
 
 
 class Variable:

--- a/lnn/utils.py
+++ b/lnn/utils.py
@@ -4,15 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from . import _utils
-from .constants import Fact
-
 import random
 import itertools
+from typing import Union, Tuple, List, TypeVar
+
 import numpy as np
 import networkx as nx
 import matplotlib.pyplot as plt
-from typing import Union, Tuple, List, TypeVar
+
+from . import _utils
+from .constants import Fact
 
 
 TRUE = Fact.TRUE

--- a/tests/learning/fol/test_supervised_atagent_1.py
+++ b/tests/learning/fol/test_supervised_atagent_1.py
@@ -5,6 +5,7 @@
 ##
 
 import itertools
+
 from lnn import (Model, World, And, Bidirectional, ForAll, Variable,
                  TRUE, UPWARD)
 

--- a/tests/learning/fol/test_supervised_atlocation_1.py
+++ b/tests/learning/fol/test_supervised_atlocation_1.py
@@ -5,6 +5,7 @@
 ##
 
 import itertools
+
 from lnn import (Model, World, And, Bidirectional, ForAll, Variable,
                  TRUE, UPWARD)
 

--- a/tests/learning/fol/test_supervised_atlocation_2.py
+++ b/tests/learning/fol/test_supervised_atlocation_2.py
@@ -5,6 +5,7 @@
 ##
 
 import itertools
+
 from lnn import (Model, World, And, Bidirectional, ForAll, Variable,
                  TRUE, UPWARD, UNKNOWN, Implies)
 

--- a/tests/learning/fol/test_supervised_family_tree.py
+++ b/tests/learning/fol/test_supervised_family_tree.py
@@ -6,6 +6,7 @@
 
 import itertools
 import random
+
 from lnn import (Model, World, And, Bidirectional, ForAll, Variable,
                  TRUE, FALSE, UPWARD)
 

--- a/tests/learning/lifted/teaches.py
+++ b/tests/learning/lifted/teaches.py
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Model, Predicate, Variable, Implies, And, plot_graph, \
-    AXIOM, CLOSED
+from lnn import (Model, Predicate, Variable, Implies, And, plot_graph,
+                 AXIOM, CLOSED)
+
 
 model = Model()
 

--- a/tests/learning/propositional/test_bool_and_1.py
+++ b/tests/learning/propositional/test_bool_and_1.py
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Model, And, Proposition, World, UPWARD, FALSE, TRUE, CLOSED
 import random
+
+from lnn import Model, And, Proposition, World, UPWARD, FALSE, TRUE, CLOSED
 
 
 def test_1():

--- a/tests/reasoning/gm/_test_bool_and_4.py
+++ b/tests/reasoning/gm/_test_bool_and_4.py
@@ -6,6 +6,7 @@
 
 from lnn import Predicate, And, Model, Variable, World, TRUE
 
+
 model = Model()
 x, y, z = map(Variable, ('x', 'y', 'z'))
 model['P'] = Predicate()

--- a/tests/reasoning/gm/test_bool_and_1.py
+++ b/tests/reasoning/gm/test_bool_and_1.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+from functools import reduce
+
+import numpy as np
 from lnn import (Predicate, And, Model, Variable,
                  truth_table, fact_to_bool, bool_to_fact)
-from functools import reduce
-import numpy as np
 
 
 def test():

--- a/tests/reasoning/gm/test_bool_and_2.py
+++ b/tests/reasoning/gm/test_bool_and_2.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+from functools import reduce
+
+import numpy as np
 from lnn import (Predicate, And, Model, Variable,
                  truth_table, fact_to_bool, bool_to_fact)
-from functools import reduce
-import numpy as np
 
 
 def test():

--- a/tests/reasoning/gm/test_bool_and_3.py
+++ b/tests/reasoning/gm/test_bool_and_3.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+from functools import reduce
+
+import numpy as np
 from lnn import (Predicate, And, Model, Variable,
                  truth_table, fact_to_bool, bool_to_fact)
-from functools import reduce
-import numpy as np
 
 
 def test():

--- a/tests/reasoning/gm/test_bool_and_4.py
+++ b/tests/reasoning/gm/test_bool_and_4.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+from functools import reduce
+
+import numpy as np
 from lnn import (Predicate, And, Model, Variable,
                  truth_table, fact_to_bool, bool_to_fact)
-from functools import reduce
-import numpy as np
 
 
 def test():

--- a/tests/reasoning/gm/test_bool_and_5.py
+++ b/tests/reasoning/gm/test_bool_and_5.py
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Predicate, And, Model, Variable, World, TRUE, Join
 import random
+
+from lnn import Predicate, And, Model, Variable, World, TRUE, Join
 
 
 def test_1():

--- a/tests/reasoning/gm/test_gm_qa.py
+++ b/tests/reasoning/gm/test_gm_qa.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, Predicate, And, Fact, Exists, Variable, Join)
+from lnn import Model, Predicate, And, Fact, Exists, Variable, Join
 
 
 def test_1():

--- a/tests/reasoning/logic/fol/test_quantifier_bound_var.py
+++ b/tests/reasoning/logic/fol/test_quantifier_bound_var.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, Variable, TRUE, FALSE, UNKNOWN, ForAll, Exists)
+from lnn import Model, Variable, TRUE, FALSE, UNKNOWN, ForAll, Exists
 
 
 def test_1():

--- a/tests/reasoning/logic/fol/test_quantifier_free_var.py
+++ b/tests/reasoning/logic/fol/test_quantifier_free_var.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, Variable, TRUE, FALSE, UNKNOWN, ForAll, Exists)
+from lnn import Model, Variable, TRUE, FALSE, UNKNOWN, ForAll, Exists
 
 
 def test_1():

--- a/tests/reasoning/logic/fol/test_rv_and_2.py
+++ b/tests/reasoning/logic/fol/test_rv_and_2.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Predicate, And, Or, Implies, Model, Variable)
 import numpy as np
+from lnn import Predicate, And, Or, Implies, Model, Variable
 
 
 def test_and():

--- a/tests/reasoning/logic/propositional/test_and_lukasiewicz_1.py
+++ b/tests/reasoning/logic/propositional/test_and_lukasiewicz_1.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Proposition, And, Model
 import numpy as np
+from lnn import Proposition, And, Model
 
 
 def test():

--- a/tests/reasoning/logic/propositional/test_bool_and_1.py
+++ b/tests/reasoning/logic/propositional/test_bool_and_1.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import numpy as np
 from lnn import (Proposition, And, Model, TRUE, FALSE, UNKNOWN, CONTRADICTION,
                  truth_table, fact_to_bool, bool_to_fact)
-import numpy as np
 
 
 def test_upward():

--- a/tests/reasoning/logic/propositional/test_bool_and_2.py
+++ b/tests/reasoning/logic/propositional/test_bool_and_2.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+from functools import reduce
+
+import numpy as np
 from lnn import (Proposition, And, Model,
                  truth_table, fact_to_bool, bool_to_fact)
-import numpy as np
-from functools import reduce
 
 
 def test():

--- a/tests/reasoning/logic/propositional/test_bool_and_n.py
+++ b/tests/reasoning/logic/propositional/test_bool_and_n.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Proposition, And, Model, TRUE, FALSE, UNKNOWN, CONTRADICTION
 import numpy as np
+from lnn import Proposition, And, Model, TRUE, FALSE, UNKNOWN, CONTRADICTION
 
 
 def test_upward():

--- a/tests/reasoning/logic/propositional/test_bool_implies_1.py
+++ b/tests/reasoning/logic/propositional/test_bool_implies_1.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import numpy as np
 from lnn import (Proposition, Implies, Model,
                  CONTRADICTION, TRUE, FALSE, UNKNOWN,
                  truth_table, fact_to_bool, bool_to_fact)
-import numpy as np
 
 
 def test_upward():

--- a/tests/reasoning/logic/propositional/test_bool_or_1.py
+++ b/tests/reasoning/logic/propositional/test_bool_or_1.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+import numpy as np
 from lnn import (Proposition, Or, Model, TRUE, FALSE, UNKNOWN, CONTRADICTION,
                  truth_table, fact_to_bool, bool_to_fact)
-import numpy as np
 
 
 def test_upward():

--- a/tests/reasoning/logic/propositional/test_bool_or_n.py
+++ b/tests/reasoning/logic/propositional/test_bool_or_n.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Proposition, Or, Model, CONTRADICTION, TRUE, FALSE, UNKNOWN
 import numpy as np
+from lnn import Proposition, Or, Model, CONTRADICTION, TRUE, FALSE, UNKNOWN
 
 
 def test_upward():

--- a/tests/reasoning/logic/propositional/test_implies_lukasiewicz_1.py
+++ b/tests/reasoning/logic/propositional/test_implies_lukasiewicz_1.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Proposition, Implies, Model
 import numpy as np
+from lnn import Proposition, Implies, Model
 
 
 def test():

--- a/tests/reasoning/logic/propositional/test_inference_rules.py
+++ b/tests/reasoning/logic/propositional/test_inference_rules.py
@@ -5,6 +5,7 @@
 ##
 
 import os
+
 import pytest
 from lnn import (Model, Proposition, Implies, And, Or, Not, TRUE, FALSE,
                  truth_table_dict)

--- a/tests/reasoning/logic/propositional/test_or_lukasiewicz_1.py
+++ b/tests/reasoning/logic/propositional/test_or_lukasiewicz_1.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Proposition, Or, Model
 import numpy as np
+from lnn import Proposition, Or, Model
 
 
 def test():

--- a/tests/reasoning/logic/propositional/test_rv_and_n.py
+++ b/tests/reasoning/logic/propositional/test_rv_and_n.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Proposition, And, Model, Fact
 import numpy as np
+from lnn import Proposition, And, Model, Fact
 
 
 def test_upward():

--- a/tests/reasoning/logic/propositional/test_rv_or_n.py
+++ b/tests/reasoning/logic/propositional/test_rv_or_n.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import Proposition, Or, Model, Fact
 import numpy as np
+from lnn import Proposition, Or, Model, Fact
 
 
 def test_upward():


### PR DESCRIPTION
Hi,

I have reordered imports according to PEP8 (https://www.python.org/dev/peps/pep-0008/#imports). Not sure if there is some specific reason to have them in original order, feel free to close this PR :)

Also I can also fix (if needed) following:
- there are places where `import itertools` and same time `from itertools import chain` is used in other file, maybe first should be preferred?
- in general I am missing more blank lines in the code, maybe some strict formatter can be use (like [black](https://github.com/psf/black))?

TM