### PR TITLE
Black code style

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,10 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://app.travis-ci.com/IBM/LNN.svg?branch=master)](https://app.travis-ci.com/IBM/LNN)
 [![License](https://img.shields.io/github/license/IBM/LNN)](https://github.com/IBM/LNN/blob/master/LICENSE)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 # Logical Neural Networks
 LNNs are a novel `Neuro = symbolic` framework designed to seamlessly provide key

--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -15,13 +15,14 @@ import os
 import sys
 import sphinx_rtd_theme  # noqa: F401
 import commonmark  # noqa: F401
-sys.path.insert(0, os.path.abspath('../../'))
+
+sys.path.insert(0, os.path.abspath("../../"))
 
 # -- Project information -----------------------------------------------------
 
-project = 'Logical Neural Networks'
-copyright = '2020, IBM Research'
-author = 'IBM Research'
+project = "Logical Neural Networks"
+copyright = "2020, IBM Research"
+author = "IBM Research"
 
 
 # -- General configuration ---------------------------------------------------
@@ -29,14 +30,10 @@ author = 'IBM Research'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-  'sphinx.ext.autodoc',
-  'myst_parser',
-  'sphinx_rtd_theme'
-]
+extensions = ["sphinx.ext.autodoc", "myst_parser", "sphinx_rtd_theme"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -49,16 +46,16 @@ exclude_patterns = list()
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 def docstring(app, what, name, obj, options, lines):
-    md = '\n'.join(lines)
+    md = "\n".join(lines)
     ast = commonmark.Parser().parse(md)
     rst = commonmark.ReStructuredTextRenderer().render(ast)
     lines.clear()
@@ -66,4 +63,4 @@ def docstring(app, what, name, obj, options, lines):
 
 
 def setup(app):
-    app.connect('autodoc-process-docstring', docstring)
+    app.connect("autodoc-process-docstring", docstring)

--- a/lnn/__init__.py
+++ b/lnn/__init__.py
@@ -5,12 +5,29 @@
 ##
 
 from .model import Model
-from .symbolic import (Proposition, Predicate, And, Or,
-                       Implies, Bidirectional, Not, ForAll, Exists, Variable,
-                       NeuralActivationClass)
-from .utils import (truth_table, truth_table_dict, predicate_truth_table,
-                    plot_graph, plot_loss, plot_params, fact_to_bool,
-                    bool_to_fact)
+from .symbolic import (
+    Proposition,
+    Predicate,
+    And,
+    Or,
+    Implies,
+    Bidirectional,
+    Not,
+    ForAll,
+    Exists,
+    Variable,
+    NeuralActivationClass,
+)
+from .utils import (
+    truth_table,
+    truth_table_dict,
+    predicate_truth_table,
+    plot_graph,
+    plot_loss,
+    plot_params,
+    fact_to_bool,
+    bool_to_fact,
+)
 from .constants import Fact, World, Direction, Join
 
 
@@ -31,24 +48,41 @@ INNER = Join.INNER
 OUTER_PRUNED = Join.OUTER_PRUNED
 
 __all__ = [
-    'Model',
-    'Proposition', 'Predicate',
-    'And', 'Or', 'Implies', 'Bidirectional', 'Not',
-    'ForAll', 'Exists', 'Variable',
-
-    'truth_table', 'truth_table_dict', 'predicate_truth_table',
-    'fact_to_bool', 'bool_to_fact',
-    'plot_graph', 'plot_loss', 'plot_params',
-
-    'Direction',
-    'UPWARD', 'DOWNWARD',
-
-    'Fact', 'World',
-    'OPEN', 'CLOSED', 'AXIOM',
-    'TRUE', 'FALSE', 'UNKNOWN', 'CONTRADICTION',
-
-    'Lukasiewicz', 'LukasiewiczTransparent',
-
-    'Join',
-    'OUTER', 'INNER', 'OUTER_PRUNED'
+    "Model",
+    "Proposition",
+    "Predicate",
+    "And",
+    "Or",
+    "Implies",
+    "Bidirectional",
+    "Not",
+    "ForAll",
+    "Exists",
+    "Variable",
+    "truth_table",
+    "truth_table_dict",
+    "predicate_truth_table",
+    "fact_to_bool",
+    "bool_to_fact",
+    "plot_graph",
+    "plot_loss",
+    "plot_params",
+    "Direction",
+    "UPWARD",
+    "DOWNWARD",
+    "Fact",
+    "World",
+    "OPEN",
+    "CLOSED",
+    "AXIOM",
+    "TRUE",
+    "FALSE",
+    "UNKNOWN",
+    "CONTRADICTION",
+    "Lukasiewicz",
+    "LukasiewiczTransparent",
+    "Join",
+    "OUTER",
+    "INNER",
+    "OUTER_PRUNED",
 ]

--- a/lnn/_exceptions.py
+++ b/lnn/_exceptions.py
@@ -16,12 +16,14 @@ class AssertWorld:
 
     Raised when world not given as World object
     """
+
     def __init__(self, world: World):
         if world not in World:
             raise KeyError(
-                'truth world assumption expects lnn.World object from '
-                f'{[w.name for w in World]}, received '
-                f'{world.__class__.__name__} {world}')
+                "truth world assumption expects lnn.World object from "
+                f"{[w.name for w in World]}, received "
+                f"{world.__class__.__name__} {world}"
+            )
 
 
 class AssertBoundsBroadcasting:
@@ -29,10 +31,11 @@ class AssertBoundsBroadcasting:
 
     Raised when FOL bounds given as set of more than 1 item
     """
+
     def __init__(self, bounds: Set):
         if isinstance(bounds, set):
             if len(bounds) != 1:
-                raise IndexError('broadcasting facts expects a set of 1 item')
+                raise IndexError("broadcasting facts expects a set of 1 item")
 
 
 class AssertBoundsType:
@@ -42,8 +45,9 @@ class AssertBoundsType:
         options = [Fact, tuple]
         if type(bounds) not in options:
             raise TypeError(
-                f'fact expected from [lnn.Fact, tuple] '
-                f'received {bounds.__class__.__name__} {bounds}')
+                f"fact expected from [lnn.Fact, tuple] "
+                f"received {bounds.__class__.__name__} {bounds}"
+            )
 
 
 class AssertBoundsLen:
@@ -51,12 +55,14 @@ class AssertBoundsLen:
 
     Raised when tuple of bounds given in the incorrect length
     """
+
     def __init__(self, bounds):
         if isinstance(bounds, tuple):
             if len(bounds) != 2:
                 raise IndexError(
-                    'bounds tuple expected to have 2 bounds (Lower, Upper), '
-                    f'received {bounds}')
+                    "bounds tuple expected to have 2 bounds (Lower, Upper), "
+                    f"received {bounds}"
+                )
 
 
 class AssertBoundsInputs:
@@ -64,12 +70,13 @@ class AssertBoundsInputs:
 
     Raised when incorrect bounds given
     """
+
     def __init__(self, bounds: Tuple[torch.Tensor, ...]):
         if isinstance(bounds, tuple):
             if any([not 0 <= b <= 1 for b in bounds]):
                 raise IndexError(
-                    'bounds expected to be in range [0, 1], '
-                    f'received {bounds}')
+                    "bounds expected to be in range [0, 1], " f"received {bounds}"
+                )
 
 
 class AssertBounds:
@@ -77,6 +84,7 @@ class AssertBounds:
 
     Raised when tuple of bounds given in the incorrect length
     """
+
     def __init__(self, bounds):
         AssertBoundsType(bounds)
         AssertBoundsLen(bounds)
@@ -86,18 +94,19 @@ class AssertBounds:
 
 class AssertPropositionalInheritance:
     def __init__(self, node):
-        if not hasattr(node, 'propositional'):
-            raise Exception("should not end up here, propositional variable "
-                            "expected to be declared at proposition/predicate"
-                            "and inherited appropriately... you may have an"
-                            "incorrectly connected the node")
+        if not hasattr(node, "propositional"):
+            raise Exception(
+                "should not end up here, propositional variable "
+                "expected to be declared at proposition/predicate"
+                "and inherited appropriately... you may have an"
+                "incorrectly connected the node"
+            )
 
 
 class AssertFormulaInModel:
     def __init__(self, model, formula):
         if formula not in model:
-            raise Exception(
-                f"{formula} is not a stored formula, can't set facts")
+            raise Exception(f"{formula} is not a stored formula, can't set facts")
 
 
 class AssertGroundingKeyType:
@@ -105,12 +114,13 @@ class AssertGroundingKeyType:
 
     Raised when fact keys are not valid groundings
     """
+
     def __init__(self, facts):
         if isinstance(facts, dict):
             if all([type(f) not in [tuple, Fact] for f in facts.keys()]):
                 raise TypeError(
-                    'fact keys expected as str or tuple of str'
-                    f'received {facts}')
+                    "fact keys expected as str or tuple of str" f"received {facts}"
+                )
 
 
 class AssertFOLFacts:
@@ -119,6 +129,7 @@ class AssertFOLFacts:
     Raised when FOL bounds expected as a dict of {groundings: facts}
 
     """
+
     def __init__(self, facts: Dict):
         if isinstance(facts, dict):
             for grounding, bounds in facts.items():
@@ -131,6 +142,7 @@ class AssertDirection:
 
     Raised when direction input is not valid
     """
+
     def __init__(self, direction: Direction):
         AssertDirectionType(direction)
         AssertValidDirection(direction)
@@ -141,12 +153,11 @@ class AssertValidDirection:
 
     Raised when direction not upward/downward
     """
+
     def __init__(self, direction: Direction):
         options = [Direction.UPWARD, Direction.DOWNWARD]
         if direction not in options:
-            raise KeyError(
-                f'direction expected from {options}, '
-                f'found {direction}')
+            raise KeyError(f"direction expected from {options}, " f"found {direction}")
 
 
 class AssertDirectionType:
@@ -154,10 +165,12 @@ class AssertDirectionType:
 
     Raised when direction not a clarified str
     """
+
     def __init__(self, direction: Direction):
         if not isinstance(direction, Direction):
-            raise TypeError(f'direction expected as Direction, '
-                            f'received {direction}')
+            raise TypeError(
+                f"direction expected as Direction, " f"received {direction}"
+            )
 
 
 class AssertBias:
@@ -165,10 +178,10 @@ class AssertBias:
 
     Raised when direction not a clarified str
     """
+
     def __init__(self, bias):
         if not isinstance(bias, float):
-            raise TypeError(
-                f'bias expected as a float, received {type(bias)}: {bias}')
+            raise TypeError(f"bias expected as a float, received {type(bias)}: {bias}")
 
 
 class AssertWeights:
@@ -176,14 +189,17 @@ class AssertWeights:
 
     Raised when direction not a clarified str
     """
+
     def __init__(self, weights: Tuple, arity: int):
         if not isinstance(weights, tuple):
             raise TypeError(
-                'weights expected as a tuple of floats, received '
-                f'{type(weights)}: {weights}')
+                "weights expected as a tuple of floats, received "
+                f"{type(weights)}: {weights}"
+            )
         if not len(weights) == arity:
             raise ValueError(
-                f'weights expected as len {arity}, received {len(weights)}')
+                f"weights expected as len {arity}, received {len(weights)}"
+            )
 
 
 class AssertAlphaNodeValue:
@@ -193,9 +209,8 @@ class AssertAlphaNodeValue:
     """
 
     def __init__(self, alpha):
-        if not (.5 < alpha <= 1):
-            raise ValueError(
-                f'alpha expected between (.5, 1], received {alpha}')
+        if not (0.5 < alpha <= 1):
+            raise ValueError(f"alpha expected between (.5, 1], received {alpha}")
 
 
 class AssertAlphaNeuronArityValue:
@@ -205,8 +220,9 @@ class AssertAlphaNeuronArityValue:
     """
 
     def __init__(self, alpha, arity):
-        constraint = arity/(arity+1)
+        constraint = arity / (arity + 1)
         if not (alpha >= constraint):
             raise ValueError(
-                f'alpha expected greater than n/(n+1) ({constraint:<.3e}) '
-                f'for n={arity}, received {alpha:<3e}')
+                f"alpha expected greater than n/(n+1) ({constraint:<.3e}) "
+                f"for n={arity}, received {alpha:<3e}"
+            )

--- a/lnn/_utils.py
+++ b/lnn/_utils.py
@@ -25,8 +25,10 @@ class MultiInstance:
         elif isinstance(term, str):
             pass
         else:
-            raise Exception(f'expected {self.__class__.__name__} inputs from '
-                            f'[str, list], received {type(term)}')
+            raise Exception(
+                f"expected {self.__class__.__name__} inputs from "
+                f"[str, list], received {type(term)}"
+            )
 
 
 class UniqueNameAssumption:
@@ -49,8 +51,9 @@ class UniqueNameAssumption:
         if key in cls.instances:
             return cls.instances[key]
         raise LookupError(
-            f'should not end up here, {type(key)} key {key} not found in '
-            f'Groundings {list(cls.instances.keys())}')
+            f"should not end up here, {type(key)} key {key} not found in "
+            f"Groundings {list(cls.instances.keys())}"
+        )
 
     @classmethod
     def __setitem__(cls, key: str, val: any):
@@ -98,11 +101,11 @@ class UniqueNameAssumption:
 
 
 def fact_to_bounds(
-        fact: Union[Fact, World],
-        propositional: bool,
-        dims: list = None,
-        requires_grad: bool = False
-        ) -> torch.Tensor:
+    fact: Union[Fact, World],
+    propositional: bool,
+    dims: list = None,
+    requires_grad: bool = False,
+) -> torch.Tensor:
     """Create classical bounds tensor
 
     bounds tensor repeats over dims according to (batch, groundings)
@@ -128,31 +131,33 @@ def fact_to_bounds(
     if isinstance(fact, torch.Tensor):
         return fact
 
-    sizes = dims+[1] if dims else (1 if propositional else [1, 1])
+    sizes = dims + [1] if dims else (1 if propositional else [1, 1])
     if isinstance(fact, tuple):
         _exceptions.AssertBoundsLen(fact)
     elif type(fact) in [World, Fact]:
         fact = fact.value
-    return torch.tensor(tuple(map(float, fact))).repeat(
-        sizes).requires_grad_(requires_grad)
+    return (
+        torch.tensor(tuple(map(float, fact)))
+        .repeat(sizes)
+        .requires_grad_(requires_grad)
+    )
 
 
 def negate_bounds(bounds: torch.Tensor, dim=-1) -> torch.Tensor:
-    """"negate a bounds tensor: (1 - U, 1 - L)"""
+    """ "negate a bounds tensor: (1 - U, 1 - L)"""
     return (1 - bounds).flip(dim)
 
 
 def node_state(state: np.ScalarType):
     result = {
-        'U': Fact.UNKNOWN,
-        'T': Fact.TRUE,
-        'F': Fact.FALSE,
-        'C': Fact.CONTRADICTION,
-
-        '~F': _Fact.APPROX_FALSE,
-        '~U': _Fact.APPROX_UNKNOWN,
-        '=U': _Fact.EXACT_UNKNOWN,
-        '~T': _Fact.APPROX_TRUE,
+        "U": Fact.UNKNOWN,
+        "T": Fact.TRUE,
+        "F": Fact.FALSE,
+        "C": Fact.CONTRADICTION,
+        "~F": _Fact.APPROX_FALSE,
+        "~U": _Fact.APPROX_UNKNOWN,
+        "=U": _Fact.EXACT_UNKNOWN,
+        "~T": _Fact.APPROX_TRUE,
     }
     return result[state.item()]
 
@@ -162,9 +167,13 @@ def dict_rekey(d, old_key, new_key) -> None:
 
 
 param_symbols = {
-    'alpha': 'α', 'bias': 'β', 'weights': 'w',
-    'weights.grad': 'w.g', 'bias.grad': 'β.g'}
-Model = TypeVar('Model')
+    "alpha": "α",
+    "bias": "β",
+    "weights": "w",
+    "weights.grad": "w.g",
+    "bias.grad": "β.g",
+}
+Model = TypeVar("Model")
 
 
 def plot_autograd(model: Model, loss: torch.Tensor, **kwds) -> None:
@@ -172,9 +181,9 @@ def plot_autograd(model: Model, loss: torch.Tensor, **kwds) -> None:
     torchviz.make_dot(
         loss,
         params=params,
-        show_attrs=kwds.get('show_attrs', True),
-        show_saved=kwds.get('show_saved', True)).render(
-            f'graph_{kwds.get("epoch", "")}', view=True)
+        show_attrs=kwds.get("show_attrs", True),
+        show_saved=kwds.get("show_saved", True),
+    ).render(f'graph_{kwds.get("epoch", "")}', view=True)
 
 
 def val_clamp(x, _min: float = 0, _max: float = 1) -> torch.Tensor:
@@ -189,8 +198,7 @@ checkpoints = []
 
 def unpack_checkpoints():
     for t in range(len(checkpoints) - 1):
-        print(f'{checkpoints[t+1][1]}: '
-              f'{checkpoints[t+1][0] - checkpoints[t][0]}')
+        print(f"{checkpoints[t+1][1]}: " f"{checkpoints[t+1][0] - checkpoints[t][0]}")
 
 
 def add_checkpoint(label):

--- a/lnn/_utils.py
+++ b/lnn/_utils.py
@@ -144,7 +144,7 @@ def fact_to_bounds(
 
 
 def negate_bounds(bounds: torch.Tensor, dim=-1) -> torch.Tensor:
-    """ "negate a bounds tensor: (1 - U, 1 - L)"""
+    """Negate a bounds tensor: (1 - U, 1 - L)"""
     return (1 - bounds).flip(dim)
 
 

--- a/lnn/constants.py
+++ b/lnn/constants.py
@@ -27,6 +27,7 @@ class AutoName(Enum):
     ```
 
     """
+
     def _generate_next_value_(self, start, count, last_values):
         return self
 

--- a/lnn/model.py
+++ b/lnn/model.py
@@ -93,7 +93,8 @@ class Model:
     ```
 
     """
-    def __init__(self, name: str = 'Model'):
+
+    def __init__(self, name: str = "Model"):
         self.graph = nx.DiGraph()
         self.nodes = dict()
         self.name = name
@@ -115,9 +116,11 @@ class Model:
         _utils.dict_rekey(self.nodes, formula.name, name)
         self.nodes[name].rename(name)
         if name in self.__dict__:
-            warnings.warn(f'{name} already exists as a model variable the '
-                          f'existing object {repr(self.__dict__[name])} will '
-                          'be overtten')
+            warnings.warn(
+                f"{name} already exists as a model variable the "
+                f"existing object {repr(self.__dict__[name])} will "
+                "be overtten"
+            )
             self.__dict__.update({name: formula})
 
     def __contains__(self, key: str):
@@ -179,11 +182,16 @@ class Model:
         if world is not World.OPEN:
             [self[f.name]._set_world(world) for f in formulae]
 
-    def add_facts(self,
-                  facts: Dict[str,
-                              Union[Union[Fact, Tuple[float, float]],
-                                    Dict[Union[str, Tuple[str, ...]],
-                                         Union[Fact, Tuple[float, float]]]]]):
+    def add_facts(
+        self,
+        facts: Dict[
+            str,
+            Union[
+                Union[Fact, Tuple[float, float]],
+                Dict[Union[str, Tuple[str, ...]], Union[Fact, Tuple[float, float]]],
+            ],
+        ],
+    ):
         r"""Append facts to the model
 
         Assumes that the formulae that require facts have already been inserted
@@ -257,11 +265,14 @@ class Model:
             self[formula]._add_facts(fact)
 
     def add_labels(
-            self,
-            labels: Union[
-                Dict[str, Union[Tuple[float, float], Fact]],
-                Dict[str, Dict[Union[str, Tuple[str, ...]],
-                               Union[Tuple[float, float], Fact]]]]):
+        self,
+        labels: Union[
+            Dict[str, Union[Tuple[float, float], Fact]],
+            Dict[
+                str, Dict[Union[str, Tuple[str, ...]], Union[Tuple[float, float], Fact]]
+            ],
+        ],
+    ):
         r"""Append labels to the model
 
         Adding labels to formulae in the model follows the same dictionary
@@ -277,11 +288,13 @@ class Model:
                 _exceptions.AssertFOLFacts(label)
             self[formula]._add_labels(label)
 
-    def _traverse_execute(self,
-                          func: str,
-                          direction: Direction = Direction.UPWARD,
-                          source: _Formula = None,
-                          **kwds):
+    def _traverse_execute(
+        self,
+        func: str,
+        direction: Direction = Direction.UPWARD,
+        source: _Formula = None,
+        **kwds,
+    ):
         r"""Traverse over the model and execute a node operation
 
         Traverses through graph from `source` in the given `direction`
@@ -293,13 +306,12 @@ class Model:
         if direction is Direction.UPWARD:
             nodes = list(nx.dfs_postorder_nodes(self.graph, source))
         elif direction is Direction.DOWNWARD:
-            nodes = list(reversed(list(nx.dfs_postorder_nodes(
-                self.graph, source))))
+            nodes = list(reversed(list(nx.dfs_postorder_nodes(self.graph, source))))
 
-        coalesce = torch.tensor(0.)
+        coalesce = torch.tensor(0.0)
         for node in nodes:
             val = getattr(node, func)(**kwds) if hasattr(node, func) else None
-            coalesce = coalesce + val if val is not None else coalesce + 0.
+            coalesce = coalesce + val if val is not None else coalesce + 0.0
         return coalesce
 
     def lifted_preprocessing(self, n: Union[float, int]):
@@ -318,14 +330,16 @@ class Model:
             if result and result.name not in self.nodes:
                 self.add_formulae(result)
                 subformulae.append(self[str(result)])
-                print(f'Added {str(result)}')
+                print(f"Added {str(result)}")
         print(f'{"*" * 75}')
 
-    def infer(self,
-              direction: Direction = None,
-              source: _Formula = None,
-              max_steps: int = None,
-              **kwds):
+    def infer(
+        self,
+        direction: Direction = None,
+        source: _Formula = None,
+        max_steps: int = None,
+        **kwds,
+    ):
         r"""Reasons over all possible inferences until convergence
 
         **Return**
@@ -358,22 +372,26 @@ class Model:
                     nodes.
 
         """
-        lifted = kwds.get('lifted')
+        lifted = kwds.get("lifted")
         if lifted:
             self.lifted_preprocessing(1e3 if lifted is True else lifted)
-        direction = ([Direction.UPWARD, Direction.DOWNWARD]
-                     if not direction else [direction])
+        direction = (
+            [Direction.UPWARD, Direction.DOWNWARD] if not direction else [direction]
+        )
         converged = False
         steps = 0
         facts_inferred = torch.tensor(0)
         while not converged:
-            bounds_diff = 0.
+            bounds_diff = 0.0
             for d in direction:
                 bounds_diff = bounds_diff + self._traverse_execute(
-                    d.value.lower(), d, source, **kwds)
-            converged = True if direction in (
-                [[Direction.UPWARD], [Direction.DOWNWARD]]) else (
-                    bounds_diff <= 1e-7)
+                    d.value.lower(), d, source, **kwds
+                )
+            converged = (
+                True
+                if direction in ([[Direction.UPWARD], [Direction.DOWNWARD]])
+                else (bounds_diff <= 1e-7)
+            )
             facts_inferred = facts_inferred + bounds_diff
             steps = steps + 1
             if max_steps is not None and steps >= max_steps:
@@ -461,62 +479,65 @@ class Model:
 
         """
         optimizer = kwds.get(
-            'optimizer',
+            "optimizer",
             torch.optim.Adam(
-                kwds.get('parameters', self.parameters()),
-                lr=kwds.get('learning_rate', 5e-2)))
+                kwds.get("parameters", self.parameters()),
+                lr=kwds.get("learning_rate", 5e-2),
+            ),
+        )
         running_loss, loss_history, inference_history = [], [], []
         for epoch in tqdm(
-                range(int(kwds.get('epochs', 3e2))),
-                desc='training epoch', disable=not kwds.get('pbar', False)):
+            range(int(kwds.get("epochs", 3e2))),
+            desc="training epoch",
+            disable=not kwds.get("pbar", False),
+        ):
             optimizer.zero_grad()
             if epoch > 0:
                 self.reset_bounds()
-            self.increment_param_history(kwds.get('parameter_history'))
+            self.increment_param_history(kwds.get("parameter_history"))
             _, facts_inferred = self.infer(**kwds)
-            loss_fn = self.loss_fn(kwds.get('losses'))
+            loss_fn = self.loss_fn(kwds.get("losses"))
             loss = sum(loss_fn)
             if not loss.grad_fn:
                 raise RuntimeError(
-                    'graph loss found no gradient... '
-                    'check learning flags, loss functions, labels '
-                    'or switch to reasoning without learning')
+                    "graph loss found no gradient... "
+                    "check learning flags, loss functions, labels "
+                    "or switch to reasoning without learning"
+                )
             loss.backward()
             optimizer.step()
             self._project_params()
             running_loss.append(loss.item())
-            loss_history.append(
-                [L.clone().detach().tolist() for L in loss_fn])
+            loss_history.append([L.clone().detach().tolist() for L in loss_fn])
             inference_history.append(facts_inferred.item())
-            if loss <= 1e-5 and kwds.get('stop_at_convergence', True):
+            if loss <= 1e-5 and kwds.get("stop_at_convergence", True):
                 break
-        self.increment_param_history(kwds.get('parameter_history'))
+        self.increment_param_history(kwds.get("parameter_history"))
         return (running_loss, loss_history), inference_history
 
     def parameters(self):
-        result = list(chain.from_iterable(
-            [self[n].parameters() for n in self.nodes]))
+        result = list(chain.from_iterable([self[n].parameters() for n in self.nodes]))
         return result
 
     def parameters_grouped_by_neuron(self):
         result = list()
         for n in self.nodes:
             param_group = dict()
-            param_group['params'] = list()
-            param_group['param_names'] = list()
+            param_group["params"] = list()
+            param_group["param_names"] = list()
             for name, param in self[n].named_parameters():
-                param_group['params'].append(param)
-                param_group['param_names'].append(name)
-            param_group['neuron_type'] = self[n].__class__.__name__
+                param_group["params"].append(param)
+                param_group["param_names"].append(name)
+            param_group["neuron_type"] = self[n].__class__.__name__
             result.append(param_group)
         return result
 
     def named_parameters(self):
         result = dict()
         for n in self.nodes:
-            result.update({
-                f'{n}.{name}': param
-                for name, param in self[n].named_parameters()})
+            result.update(
+                {f"{n}.{name}": param for name, param in self[n].named_parameters()}
+            )
         return result
 
     def fit(self, **kwds):
@@ -526,63 +547,68 @@ class Model:
     learn = fit
 
     def loss_fn(self, losses):
-        loss_names = ['contradiction', 'uncertainty', 'logical', 'supervised',
-                      'custom']
+        loss_names = ["contradiction", "uncertainty", "logical", "supervised", "custom"]
         if losses is None:
             raise Exception(
-                'no loss function given, '
-                f'expected losses from the following {loss_names}')
+                "no loss function given, "
+                f"expected losses from the following {loss_names}"
+            )
         elif isinstance(losses, list):
             losses = {c: None for c in losses}
         result = list()
         for loss in losses:
             if loss in loss_names:
-                if loss == 'custom':
+                if loss == "custom":
                     if not isinstance(losses[loss], dict):
                         raise TypeError(
-                            'custom losses expected as a dict with keys as '
-                            'name of the loss and values as function '
-                            'definitions')
+                            "custom losses expected as a dict with keys as "
+                            "name of the loss and values as function "
+                            "definitions"
+                        )
                     for loss_fn in losses[loss].values():
-                        coalesce = torch.tensor(0.)
+                        coalesce = torch.tensor(0.0)
                         for node in list(nx.dfs_postorder_nodes(self.graph)):
                             coalesce = coalesce + loss_fn(node)
                         result.append(coalesce)
                 else:
-                    kwds = losses[loss] if (
-                        isinstance(losses[loss], dict)) else (
-                        {'coeff': losses[loss]})
-                    result.append(self._traverse_execute(
-                        f'{loss}_loss', **kwds))
+                    kwds = (
+                        losses[loss]
+                        if (isinstance(losses[loss], dict))
+                        else ({"coeff": losses[loss]})
+                    )
+                    result.append(self._traverse_execute(f"{loss}_loss", **kwds))
         return result
 
-    def print(self,
-              header_len: int = 50,
-              roundoff: int = 5,
-              params: bool = False,
-              grads: bool = False,
-              ):
+    def print(
+        self,
+        header_len: int = 50,
+        roundoff: int = 5,
+        params: bool = False,
+        grads: bool = False,
+    ):
         n = header_len + 25
-        print('\n' + '*' * n + f'\n{"":<{n/2 - 5}}LNN {self.name}\n')
-        self._traverse_execute('print',
-                               Direction.DOWNWARD,
-                               header_len=header_len,
-                               roundoff=roundoff,
-                               params=params,
-                               grads=grads)
-        print('*' * n)
+        print("\n" + "*" * n + f'\n{"":<{n/2 - 5}}LNN {self.name}\n')
+        self._traverse_execute(
+            "print",
+            Direction.DOWNWARD,
+            header_len=header_len,
+            roundoff=roundoff,
+            params=params,
+            grads=grads,
+        )
+        print("*" * n)
 
     def flush(self):
-        self._traverse_execute('flush')
+        self._traverse_execute("flush")
 
     def reset_bounds(self):
-        self._traverse_execute('reset_bounds')
+        self._traverse_execute("reset_bounds")
 
     def _project_params(self):
-        self._traverse_execute('project_params')
+        self._traverse_execute("project_params")
 
     def increment_param_history(self, parameter_history):
         if parameter_history:
             self._traverse_execute(
-                'increment_param_history',
-                parameter_history=parameter_history)
+                "increment_param_history", parameter_history=parameter_history
+            )

--- a/lnn/neural/__init__.py
+++ b/lnn/neural/__init__.py
@@ -6,4 +6,4 @@
 
 from .methods.lukasiewicz import Lukasiewicz
 
-__all__ = ['Lukasiewicz']
+__all__ = ["Lukasiewicz"]

--- a/lnn/neural/activations/neuron/dynamic.py
+++ b/lnn/neural/activations/neuron/dynamic.py
@@ -13,6 +13,7 @@ class _DynamicActivation(_NeuronActivation):
     """
     Dynamic neuron activation function
     """
+
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
         self.Xmin = 0
@@ -23,15 +24,14 @@ class _DynamicActivation(_NeuronActivation):
 
     def input_regions(self, bounds) -> torch.Tensor:
         result = torch.zeros_like(bounds)
-        result = result.masked_fill(
-            (self.Xmin <= bounds) * (bounds <= self.Xf), 1)
-        result = result.masked_fill(
-            (self.Xf < bounds) * (bounds < self.Xt), 2)
-        result = result.masked_fill(
-            (self.Xt <= bounds) * (bounds <= self.Xmax), 3)
+        result = result.masked_fill((self.Xmin <= bounds) * (bounds <= self.Xf), 1)
+        result = result.masked_fill((self.Xf < bounds) * (bounds < self.Xt), 2)
+        result = result.masked_fill((self.Xt <= bounds) * (bounds <= self.Xmax), 3)
         if any(result == 0):
-            raise ValueError('Unknown input regions. Expected all values from '
-                             f'[1, 2, 3], received  {result}')
+            raise ValueError(
+                "Unknown input regions. Expected all values from "
+                f"[1, 2, 3], received  {result}"
+            )
         return result
 
     class TransparentMax(torch.autograd.Function):
@@ -42,16 +42,14 @@ class _DynamicActivation(_NeuronActivation):
 
         @staticmethod
         def backward(ctx, grad_output):
-            bounds, = ctx.saved_tensors
+            (bounds,) = ctx.saved_tensors
             flags = bounds == bounds.max()
             grad_input = torch.ones_like(bounds) * grad_output.clone()
             grad_input = grad_input.where(flags, torch.zeros_like(bounds))
             return grad_input
 
     @staticmethod
-    def divide(divident: torch.Tensor,
-               divisor: torch.Tensor, fill=1.
-               ) -> torch.Tensor:
+    def divide(divident: torch.Tensor, divisor: torch.Tensor, fill=1.0) -> torch.Tensor:
         """
         Divide the bounds tensor (divident) by weights (divisor) while
             respecting gradient connectivity
@@ -60,8 +58,7 @@ class _DynamicActivation(_NeuronActivation):
         shape = divident.shape
         if divident.dim() < 2:
             divident = divident.reshape(1, -1)
-        div = divident.masked_select(divisor != 0) / divisor.masked_select(
-            divisor != 0)
+        div = divident.masked_select(divisor != 0) / divisor.masked_select(divisor != 0)
         result = divident.masked_scatter(divisor != 0, div)
         result = result.masked_fill(divisor == 0, fill)
         return result.reshape(shape)

--- a/lnn/neural/activations/neuron/neuron.py
+++ b/lnn/neural/activations/neuron/neuron.py
@@ -25,29 +25,27 @@ class _NeuronActivation(_NodeActivation, _NeuronParameters):
         self.Xmid = 0.5
 
     def function(self, func: str, direction: Direction) -> torch.Tensor:
-        return getattr(self, '_'+func.lower())(direction)
+        return getattr(self, "_" + func.lower())(direction)
 
     @torch.no_grad()
-    def downward_conditional(self,
-                             out_bounds: torch.Tensor,
-                             f_inv: torch.Tensor,
-                             input_terms: torch.Tensor
-                             ) -> torch.Tensor:
+    def downward_conditional(
+        self, out_bounds: torch.Tensor, f_inv: torch.Tensor, input_terms: torch.Tensor
+    ) -> torch.Tensor:
         full_and_input = input_terms.sum(dim=-1)[..., None]
         partial_and_input = (full_and_input - input_terms).flip([-2])
         result = 1 + (
             (f_inv[..., None] - self.bias + partial_and_input)
-            / self.weights.clamp(min=0))
+            / self.weights.clamp(min=0)
+        )
         unknown = torch.ones_like(result)
         unknown[..., 0, :] = 0
-        out_repeat = out_bounds[..., None].repeat_interleave(
-            unknown.shape[-1], dim=-1)
+        out_repeat = out_bounds[..., None].repeat_interleave(unknown.shape[-1], dim=-1)
         result[..., 0, :] = result[..., 0, :].where(
-            out_repeat[..., 0, :] > 1 - self.alpha,
-            unknown[..., 0, :])
+            out_repeat[..., 0, :] > 1 - self.alpha, unknown[..., 0, :]
+        )
         result[..., 1, :] = result[..., 1, :].where(
-            out_repeat[..., 1, :] < self.alpha,
-            unknown[..., 1, :])
+            out_repeat[..., 1, :] < self.alpha, unknown[..., 1, :]
+        )
 
         weight_repeat = self.weights[None].repeat_interleave(2, dim=0)
         result = result.where(weight_repeat != 0, unknown)

--- a/lnn/neural/methods/dynamiclinear.py
+++ b/lnn/neural/methods/dynamiclinear.py
@@ -16,17 +16,17 @@ class DynamicLinear(_DynamicActivation):
 
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
-        self.w_m_slacks = kwds.get('w_m_slacks', 'max')
-        self.kappa = self.add_param('kappa', torch.tensor(1.))
-        self.kappa.requires_grad_(kwds.get('kappa_learning', False))
+        self.w_m_slacks = kwds.get("w_m_slacks", "max")
+        self.kappa = self.add_param("kappa", torch.tensor(1.0))
+        self.kappa.requires_grad_(kwds.get("kappa_learning", False))
 
     def _and(self, direction: Direction):
-        self.kappa.data = torch.tensor(1.)
+        self.kappa.data = torch.tensor(1.0)
         self.update_activation()
         return self._and_or(direction)
 
     def _or(self, direction: Direction):
-        self.kappa.data = torch.tensor(0.)
+        self.kappa.data = torch.tensor(0.0)
         self.update_activation()
         return self._and_or(direction)
 
@@ -45,14 +45,16 @@ class DynamicLinear(_DynamicActivation):
             lhs = in_bounds[..., 0]
             rhs = _not(in_bounds[..., 1])
             implies_bounds = torch.stack((lhs, rhs), dim=2)
-            tmp_bounds = self._and(Direction.DOWNWARD)(
-                _not(out_bounds), implies_bounds)
+            tmp_bounds = self._and(Direction.DOWNWARD)(_not(out_bounds), implies_bounds)
             return torch.stack(
-                [tmp_bounds[..., 0], _not(tmp_bounds[..., 1], dim=-1)],
-                dim=-1)
+                [tmp_bounds[..., 0], _not(tmp_bounds[..., 1], dim=-1)], dim=-1
+            )
 
-        return upward if direction is Direction.UPWARD else (
-            downward if direction is Direction.DOWNWARD else None)
+        return (
+            upward
+            if direction is Direction.UPWARD
+            else (downward if direction is Direction.DOWNWARD else None)
+        )
 
     def _and_or(self, direction: Direction):
         def upward(in_bounds: torch.Tensor):
@@ -63,56 +65,59 @@ class DynamicLinear(_DynamicActivation):
             y = torch.where(regions == 2, self.Yf + (x - self.Xf) * self.Gz, y)
             y = torch.where(regions == 3, self.Yt + (x - self.Xt) * self.Gt, y)
             if any(y < 0) or any(y > 1) or any(y == -1):
-                raise ValueError('output of activation expected in [0, 1], '
-                                 f'received {y}')
+                raise ValueError(
+                    "output of activation expected in [0, 1], " f"received {y}"
+                )
             return y
 
         def downward(out_bounds: torch.Tensor, in_bounds: torch.Tensor):
             x = out_bounds.clone()
             regions = self.output_regions(x)
             x = torch.where(regions == 1, x * self.Gf_inv, x)
-            x = torch.where(regions == 2,
-                            self.Xf + (x - self.Yf) * self.Gz_inv, x)
-            x = torch.where(regions == 3,
-                            self.Xt + (x - self.Yt) * self.Gt_inv, x)
+            x = torch.where(regions == 2, self.Xf + (x - self.Yf) * self.Gz_inv, x)
+            x = torch.where(regions == 3, self.Xt + (x - self.Yt) * self.Gt_inv, x)
             if any(x < 0) or any(x > self.bias):
-                raise ValueError('input to activation expected in [0, 1], '
-                                 f'received {x}')
+                raise ValueError(
+                    "input to activation expected in [0, 1], " f"received {x}"
+                )
 
             input_terms = in_bounds * self.weights
-            result = (x[:, None] - (input_terms.sum(dim=1)[:, None]
-                                    - input_terms)) / self.weights
+            result = (
+                x[:, None] - (input_terms.sum(dim=1)[:, None] - input_terms)
+            ) / self.weights
             return result.clamp(0, 1)
 
-        return upward if direction is Direction.UPWARD else (
-            downward if direction is Direction.DOWNWARD else None)
+        return (
+            upward
+            if direction is Direction.UPWARD
+            else (downward if direction is Direction.DOWNWARD else None)
+        )
 
     def update_activation(self, **kwds):
         bias = self.weights[0] = self.weights[1:].sum()
         self.Xmax = bias
         w_m = self.TransparentMax.apply(
-            self.weights.max() if self.w_m_slacks == 'max' else
-            self.weights.mean() if self.w_m_slacks == 'mean' else
-            self.weights.min())
+            self.weights.max()
+            if self.w_m_slacks == "max"
+            else self.weights.mean()
+            if self.w_m_slacks == "mean"
+            else self.weights.min()
+        )
         n = self.weights.shape[-1]
         k = 1 + self.kappa * (n - 1)
         self.Xf = bias - self.alpha * (
-                w_m + ((n - k) / (n - 1 + self.eps)) * (bias - w_m))
-        self.Xt = self.alpha * (w_m + ((k - 1) / (n - 1 + self.eps)) * (
-                    bias - w_m))
-        self.Gf = self.divide(self.Yf, self.Xf,
-                              fill=0)
-        self.Gz = self.divide(self.Yt - self.Yf, self.Xt - self.Xf,
-                              fill=float('inf'))
-        self.Gt = self.divide(1 - self.Yt, self.Xmax - self.Xt,
-                              fill=0)
-        self.Gf_inv = self.divide(torch.ones_like(self.Gf), self.Gf,
-                                  fill=float('inf'))
-        self.Gz_inv = self.divide(torch.ones_like(self.Gz), self.Gz,
-                                  fill=0)
-        self.Gt_inv = self.divide(torch.ones_like(self.Gt), self.Gt,
-                                  fill=float('inf'))
+            w_m + ((n - k) / (n - 1 + self.eps)) * (bias - w_m)
+        )
+        self.Xt = self.alpha * (w_m + ((k - 1) / (n - 1 + self.eps)) * (bias - w_m))
+        self.Gf = self.divide(self.Yf, self.Xf, fill=0)
+        self.Gz = self.divide(self.Yt - self.Yf, self.Xt - self.Xf, fill=float("inf"))
+        self.Gt = self.divide(1 - self.Yt, self.Xmax - self.Xt, fill=0)
+        self.Gf_inv = self.divide(torch.ones_like(self.Gf), self.Gf, fill=float("inf"))
+        self.Gz_inv = self.divide(torch.ones_like(self.Gz), self.Gz, fill=0)
+        self.Gt_inv = self.divide(torch.ones_like(self.Gt), self.Gt, fill=float("inf"))
         uniques = [self.Xmin, self.Xf, self.Xt, self.Xmax]
         if len(uniques) < len(set(uniques)):
-            raise ValueError('expected unique values for input control '
-                             f'points, received {uniques}')
+            raise ValueError(
+                "expected unique values for input control "
+                f"points, received {uniques}"
+            )

--- a/lnn/neural/methods/lukasiewicz.py
+++ b/lnn/neural/methods/lukasiewicz.py
@@ -17,51 +17,67 @@ class Lukasiewicz(_StaticActivation):
         def upward(in_bounds: torch.Tensor):
             return (self.bias - ((1 - in_bounds) @ self.weights)).clamp(0, 1)
 
-        def downward(out_bounds: torch.Tensor,
-                     in_bounds: torch.Tensor):
-            f_inv = (out_bounds
-                     + ((out_bounds <= 0).float()
-                        * torch.stack([self.bias - self.weights.sum(),
-                                       torch.tensor(0.)]))
-                     + ((out_bounds >= 1).float()
-                        * torch.stack([torch.tensor(0.), self.bias - 1])))
+        def downward(out_bounds: torch.Tensor, in_bounds: torch.Tensor):
+            f_inv = (
+                out_bounds
+                + (
+                    (out_bounds <= 0).float()
+                    * torch.stack([self.bias - self.weights.sum(), torch.tensor(0.0)])
+                )
+                + (
+                    (out_bounds >= 1).float()
+                    * torch.stack([torch.tensor(0.0), self.bias - 1])
+                )
+            )
             input_terms = (1 - in_bounds) * self.weights
-            result = self.downward_conditional(
-                out_bounds, f_inv, input_terms)
+            result = self.downward_conditional(out_bounds, f_inv, input_terms)
             return result
 
-        return upward if direction is Direction.UPWARD else (
-            downward if direction is Direction.DOWNWARD else None)
+        return (
+            upward
+            if direction is Direction.UPWARD
+            else (downward if direction is Direction.DOWNWARD else None)
+        )
 
     def _or(self, direction: Direction):
         def upward(in_bounds: torch.Tensor):
             return (1 - self.bias + (in_bounds @ self.weights)).clamp(0, 1)
 
-        def downward(out_bounds: torch.Tensor,
-                     in_bounds: torch.Tensor):
+        def downward(out_bounds: torch.Tensor, in_bounds: torch.Tensor):
             return _not(
                 self._and(Direction.DOWNWARD)(
-                    _not(out_bounds), _not(in_bounds, dim=-2)),
-                dim=-2)
+                    _not(out_bounds), _not(in_bounds, dim=-2)
+                ),
+                dim=-2,
+            )
 
-        return upward if direction is Direction.UPWARD else (
-            downward if direction is Direction.DOWNWARD else None)
+        return (
+            upward
+            if direction is Direction.UPWARD
+            else (downward if direction is Direction.DOWNWARD else None)
+        )
 
     def _implies(self, direction: Direction):
         def upward(in_bounds: torch.Tensor):
-            result = (1 - self.bias
-                      + (self.weights[0] * (1 - in_bounds[..., 0].flip(-1)))
-                      + (self.weights[1] * in_bounds[..., 1])).clamp(0, 1)
+            result = (
+                1
+                - self.bias
+                + (self.weights[0] * (1 - in_bounds[..., 0].flip(-1)))
+                + (self.weights[1] * in_bounds[..., 1])
+            ).clamp(0, 1)
             return result
 
-        def downward(out_bounds: torch.Tensor,
-                     in_bounds: torch.Tensor):
+        def downward(out_bounds: torch.Tensor, in_bounds: torch.Tensor):
             lhs, rhs = in_bounds[..., 0], _not(in_bounds[..., 1])
             tmp_bounds = self._and(Direction.DOWNWARD)(
-                _not(out_bounds), torch.stack([lhs, rhs], dim=-1))
+                _not(out_bounds), torch.stack([lhs, rhs], dim=-1)
+            )
             return torch.stack(
-                [tmp_bounds[..., 0], _not(tmp_bounds[..., 1], dim=-1)],
-                dim=-1)
+                [tmp_bounds[..., 0], _not(tmp_bounds[..., 1], dim=-1)], dim=-1
+            )
 
-        return upward if direction is Direction.UPWARD else (
-            downward if direction is Direction.DOWNWARD else None)
+        return (
+            upward
+            if direction is Direction.UPWARD
+            else (downward if direction is Direction.DOWNWARD else None)
+        )

--- a/lnn/neural/methods/lukasiewicztransparent.py
+++ b/lnn/neural/methods/lukasiewicztransparent.py
@@ -18,53 +18,67 @@ class LukasiewiczTransparent(_StaticActivation):
         def upward(in_bounds: torch.Tensor):
             return val_clamp(self.bias - ((1 - in_bounds) @ self.weights))
 
-        def downward(out_bounds: torch.Tensor,
-                     in_bounds: torch.Tensor):
-            f_inv = (out_bounds
-                     + ((out_bounds <= 0).float()
-                        * torch.stack([self.bias - self.weights.sum(),
-                                       torch.tensor(0.)]))
-                     + ((out_bounds >= 1).float()
-                        * torch.stack([torch.tensor(0.), self.bias - 1])))
+        def downward(out_bounds: torch.Tensor, in_bounds: torch.Tensor):
+            f_inv = (
+                out_bounds
+                + (
+                    (out_bounds <= 0).float()
+                    * torch.stack([self.bias - self.weights.sum(), torch.tensor(0.0)])
+                )
+                + (
+                    (out_bounds >= 1).float()
+                    * torch.stack([torch.tensor(0.0), self.bias - 1])
+                )
+            )
             input_terms = (1 - in_bounds) * self.weights
-            result = self.downward_conditional(
-                out_bounds, f_inv, input_terms)
+            result = self.downward_conditional(out_bounds, f_inv, input_terms)
             return result
 
-        return upward if direction is Direction.UPWARD else (
-            downward if direction is Direction.DOWNWARD else None)
+        return (
+            upward
+            if direction is Direction.UPWARD
+            else (downward if direction is Direction.DOWNWARD else None)
+        )
 
     def _or(self, direction: Direction):
         def upward(in_bounds: torch.Tensor):
             return val_clamp(1 - self.bias + (in_bounds @ self.weights))
 
-        def downward(out_bounds: torch.Tensor,
-                     in_bounds: torch.Tensor):
+        def downward(out_bounds: torch.Tensor, in_bounds: torch.Tensor):
             return _not(
                 self._and(Direction.DOWNWARD)(
-                    _not(out_bounds), _not(in_bounds, dim=-2)),
-                dim=-2)
+                    _not(out_bounds), _not(in_bounds, dim=-2)
+                ),
+                dim=-2,
+            )
 
-        return upward if direction is Direction.UPWARD else (
-            downward if direction is Direction.DOWNWARD else None)
+        return (
+            upward
+            if direction is Direction.UPWARD
+            else (downward if direction is Direction.DOWNWARD else None)
+        )
 
     def _implies(self, direction: Direction):
         def upward(in_bounds: torch.Tensor):
             result = val_clamp(
-                1 - self.bias
-                + (self.weights[0] * (
-                        1 - in_bounds[..., 0].flip(-1)))
-                + (self.weights[1] * in_bounds[..., 1]))
+                1
+                - self.bias
+                + (self.weights[0] * (1 - in_bounds[..., 0].flip(-1)))
+                + (self.weights[1] * in_bounds[..., 1])
+            )
             return result
 
-        def downward(out_bounds: torch.Tensor,
-                     in_bounds: torch.Tensor):
+        def downward(out_bounds: torch.Tensor, in_bounds: torch.Tensor):
             lhs, rhs = in_bounds[..., 0], _not(in_bounds[..., 1])
             tmp_bounds = self._and(Direction.DOWNWARD)(
-                _not(out_bounds), torch.stack([lhs, rhs], dim=-1))
+                _not(out_bounds), torch.stack([lhs, rhs], dim=-1)
+            )
             return torch.stack(
-                [tmp_bounds[..., 0], _not(tmp_bounds[..., 1], dim=-1)],
-                dim=-1)
+                [tmp_bounds[..., 0], _not(tmp_bounds[..., 1], dim=-1)], dim=-1
+            )
 
-        return upward if direction is Direction.UPWARD else (
-            downward if direction is Direction.DOWNWARD else None)
+        return (
+            upward
+            if direction is Direction.UPWARD
+            else (downward if direction is Direction.DOWNWARD else None)
+        )

--- a/lnn/neural/parameters/model.py
+++ b/lnn/neural/parameters/model.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+
 class _ModelParameters:
     def __init__(self):
         self.global_alpha = 1

--- a/lnn/neural/parameters/neuron.py
+++ b/lnn/neural/parameters/neuron.py
@@ -15,14 +15,14 @@ class _NeuronParameters(_NodeParameters):
         super().__init__(propositional, truth, **kwds)
         self.arity = arity
         _exceptions.AssertAlphaNeuronArityValue(self.alpha, self.arity)
-        bias = kwds.get('bias', 1.)
+        bias = kwds.get("bias", 1.0)
         _exceptions.AssertBias(bias)
-        self.bias = self.add_param('bias', torch.tensor(bias))
-        self.bias.requires_grad_(kwds.get('bias_learning', True))
-        weights = kwds.get('weights', (1., ) * arity)
+        self.bias = self.add_param("bias", torch.tensor(bias))
+        self.bias.requires_grad_(kwds.get("bias_learning", True))
+        weights = kwds.get("weights", (1.0,) * arity)
         _exceptions.AssertWeights(weights, arity)
-        self.weights = self.add_param('weights', torch.tensor(weights))
-        self.weights.requires_grad_(kwds.get('weights_learning', True))
+        self.weights = self.add_param("weights", torch.tensor(weights))
+        self.weights.requires_grad_(kwds.get("weights_learning", True))
 
     @torch.no_grad()
     def project_params(self):

--- a/lnn/symbolic/__init__.py
+++ b/lnn/symbolic/__init__.py
@@ -1,7 +1,27 @@
-from .logic import (Proposition, Predicate, And, Or,
-                    Implies, Bidirectional, Not, ForAll, Exists, Variable,
-                    NeuralActivationClass)
+from .logic import (
+    Proposition,
+    Predicate,
+    And,
+    Or,
+    Implies,
+    Bidirectional,
+    Not,
+    ForAll,
+    Exists,
+    Variable,
+    NeuralActivationClass,
+)
 
-__all__ = ['Proposition', 'Predicate', 'And', 'Or',
-           'Implies', 'Bidirectional', 'Not', 'ForAll', 'Exists', 'Variable',
-           'NeuralActivationClass']
+__all__ = [
+    "Proposition",
+    "Predicate",
+    "And",
+    "Or",
+    "Implies",
+    "Bidirectional",
+    "Not",
+    "ForAll",
+    "Exists",
+    "Variable",
+    "NeuralActivationClass",
+]

--- a/lnn/symbolic/_gm.py
+++ b/lnn/symbolic/_gm.py
@@ -21,42 +21,39 @@ All functions in this module assume a _Formula level scope
 """
 
 
-_Grounding = TypeVar('_Grounding')
-_Formula = TypeVar('_Formula')
+_Grounding = TypeVar("_Grounding")
+_Formula = TypeVar("_Formula")
 
 
-def upward_bounds(self: _Formula,
-                  operands: Tuple[_Formula, ...],
-                  groundings: Set[Union[str, Tuple[str, ...]]] = None
-                  ) -> Union[None,
-                             Tuple[torch.Tensor, None],
-                             Tuple[torch.Tensor, Set[_Grounding]]]:
+def upward_bounds(
+    self: _Formula,
+    operands: Tuple[_Formula, ...],
+    groundings: Set[Union[str, Tuple[str, ...]]] = None,
+) -> Union[None, Tuple[torch.Tensor, None], Tuple[torch.Tensor, Set[_Grounding]]]:
     """returns (input_bounds, groundings)"""
     result = _operational_bounds(self, Direction.UPWARD, operands, groundings)
     return result
 
 
-def downward_bounds(self: _Formula,
-                    operands: Tuple[_Formula, ...],
-                    groundings: Set[Union[str, Tuple[str, ...]]] = None
-                    ) -> Union[None,
-                               Tuple[torch.Tensor,
-                                     torch.Tensor,
-                                     None],
-                               Tuple[torch.Tensor,
-                                     torch.Tensor,
-                                     Set[_Grounding]]]:
+def downward_bounds(
+    self: _Formula,
+    operands: Tuple[_Formula, ...],
+    groundings: Set[Union[str, Tuple[str, ...]]] = None,
+) -> Union[
+    None,
+    Tuple[torch.Tensor, torch.Tensor, None],
+    Tuple[torch.Tensor, torch.Tensor, Set[_Grounding]],
+]:
     """returns (output_bounds, input_bounds, groundings)"""
-    result = _operational_bounds(self, Direction.DOWNWARD,
-                                 operands, groundings)
+    result = _operational_bounds(self, Direction.DOWNWARD, operands, groundings)
     return result
 
 
-def disjoint(pred_vars): return not any(
-    [all([v in _vars for _vars in pred_vars]) for v in pred_vars[0]])
+def disjoint(pred_vars):
+    return not any([all([v in _vars for _vars in pred_vars]) for v in pred_vars[0]])
 
 
-_Variable = TypeVar('_Variable')
+_Variable = TypeVar("_Variable")
 
 
 def unique_variables(*variables: Tuple[_Variable, ...]) -> Tuple:
@@ -71,41 +68,41 @@ def unique_variables(*variables: Tuple[_Variable, ...]) -> Tuple:
     return tuple(result)
 
 
-def _operational_bounds(self: _Formula,
-                        direction: Direction,
-                        operands: Tuple[_Formula, ...],
-                        groundings: Set[Union[str, Tuple[str, ...]]] = None,
-                        ) -> Union[None,
-                                   Tuple[torch.Tensor,
-                                         None],
-                                   Tuple[torch.Tensor,
-                                         torch.Tensor,
-                                         None],
-                                   Tuple[torch.Tensor,
-                                         Set[_Grounding]],
-                                   Tuple[torch.Tensor,
-                                         torch.Tensor,
-                                         Set[_Grounding]]]:
+def _operational_bounds(
+    self: _Formula,
+    direction: Direction,
+    operands: Tuple[_Formula, ...],
+    groundings: Set[Union[str, Tuple[str, ...]]] = None,
+) -> Union[
+    None,
+    Tuple[torch.Tensor, None],
+    Tuple[torch.Tensor, torch.Tensor, None],
+    Tuple[torch.Tensor, Set[_Grounding]],
+    Tuple[torch.Tensor, torch.Tensor, Set[_Grounding]],
+]:
 
     # propositional / hash join for homogeneous operand variables
-    if (self.propositional  # propositional
-            or (all([v == self.var_remap[0]
-                     for v in self.var_remap])  # homogenous variables
-                and not self._has_bindings())):  # bindings
+    if self.propositional or (  # propositional
+        all([v == self.var_remap[0] for v in self.var_remap])  # homogenous variables
+        and not self._has_bindings()
+    ):  # bindings
         if self.propositional:  # propositional bounds
-            if True in ([op.is_contradiction() for op in operands]
-                        + [self.is_contradiction()]):
+            if True in (
+                [op.is_contradiction() for op in operands] + [self.is_contradiction()]
+            ):
                 return
             input_bounds = _masked_negate(
-                self, torch.stack([op.get_facts() for op in operands], dim=-1))
+                self, torch.stack([op.get_facts() for op in operands], dim=-1)
+            )
             if direction is Direction.UPWARD:
                 return input_bounds, None
             return self.get_facts(), input_bounds, None
 
         else:  # FOL bounds
             if groundings is None:
-                groundings = set(chain.from_iterable(
-                    [op.grounding_table for op in operands]))
+                groundings = set(
+                    chain.from_iterable([op.grounding_table for op in operands])
+                )
                 if direction is Direction.DOWNWARD:
                     groundings.update(self.grounding_table.keys())
             else:
@@ -116,8 +113,10 @@ def _operational_bounds(self: _Formula,
                     op._add_groundings(g)
 
             groundings = _hash_join(operands, groundings)
-            input_bounds = _masked_negate(self, torch.stack(
-                [op.get_facts(*groundings) for op in operands], dim=-1))
+            input_bounds = _masked_negate(
+                self,
+                torch.stack([op.get_facts(*groundings) for op in operands], dim=-1),
+            )
             self._add_groundings(*groundings)
             if direction is Direction.UPWARD:
                 return input_bounds, groundings
@@ -129,46 +128,60 @@ def _operational_bounds(self: _Formula,
     # nested loop join for bindings / heterogenous operand variables
     else:
         if self.propositional:
-            raise TypeError('proposition should not reach here')
+            raise TypeError("proposition should not reach here")
         grounding_tables = []
         for op in operands:
             g_t = dict()
             for g in op.grounding_table:
-                if g.name[0] != '(':
+                if g.name[0] != "(":
                     g_t[eval("('" + g.name + "',)")] = g
                 else:
                     g_t[eval(g.name)] = g  # op.grounding_table[g]
             grounding_tables.append(g_t)
 
-        tmp_bindings = [tuple([str(b) if b is not None else b for b in g]
-                              if isinstance(g, List)
-                              else str(g) if g is not None else g
-                              for g in op)
-                        for op in self.bindings]
-        tmp_binding_str = [', '.join([f'{v}' for v in op])
-                           for op in self.var_remap]
+        tmp_bindings = [
+            tuple(
+                [str(b) if b is not None else b for b in g]
+                if isinstance(g, List)
+                else str(g)
+                if g is not None
+                else g
+                for g in op
+            )
+            for op in self.bindings
+        ]
+        tmp_binding_str = [", ".join([f"{v}" for v in op]) for op in self.var_remap]
         if self.join_method is Join.INNER:
             ground_tuples, ground_objects = _nested_loop_join_inner(
-                grounding_tables, tmp_binding_str, tmp_bindings, operands)
+                grounding_tables, tmp_binding_str, tmp_bindings, operands
+            )
         elif self.join_method is Join.OUTER:
             ground_tuples, ground_objects = _nested_loop_join_outer(
-                grounding_tables, tmp_binding_str, tmp_bindings, operands)
+                grounding_tables, tmp_binding_str, tmp_bindings, operands
+            )
         elif self.join_method is Join.OUTER_PRUNED:
             ground_tuples, ground_objects = _nested_loop_join_outer_pruned(
-                grounding_tables, tmp_binding_str, tmp_bindings, operands)
+                grounding_tables, tmp_binding_str, tmp_bindings, operands
+            )
 
-        if ground_objects is None or \
-                all([len(o) == 0 for o in ground_objects]):
+        if ground_objects is None or all([len(o) == 0 for o in ground_objects]):
             return
 
-        tmp_ground_tuples = [g[0] for g in ground_tuples] if (
-                len(self.unique_vars) == 1) else ground_tuples
+        tmp_ground_tuples = (
+            [g[0] for g in ground_tuples]
+            if (len(self.unique_vars) == 1)
+            else ground_tuples
+        )
         groundings = tuple()
         for t in tmp_ground_tuples:
             groundings += (self._ground(t),)
-        input_bounds = _masked_negate(self, torch.stack(
-            [op.get_facts(*ground_objects[i])
-             for i, op in enumerate(operands)], dim=-1))
+        input_bounds = _masked_negate(
+            self,
+            torch.stack(
+                [op.get_facts(*ground_objects[i]) for i, op in enumerate(operands)],
+                dim=-1,
+            ),
+        )
         self._add_groundings(*groundings)
         if direction is Direction.UPWARD:
             return input_bounds, groundings
@@ -181,31 +194,31 @@ def _operational_bounds(self: _Formula,
 @torch.no_grad()
 def _nested_loop_join_outer(g_list, arg_str, bindings, operands):
     """
-        E.g  Join two Predicates P1(x,y) and P2(x,z,y) with groundings
-        (x1,y1) : g11 (ground object)  and (x1,z1,y1) : g12
-        (x2,y2) : g21 (ground object)  and (x2,z2,y2) : g22
-        (x1,y3) : g31 (ground object)  and (x2,z3,y2) : g32
+    E.g  Join two Predicates P1(x,y) and P2(x,z,y) with groundings
+    (x1,y1) : g11 (ground object)  and (x1,z1,y1) : g12
+    (x2,y2) : g21 (ground object)  and (x2,z2,y2) : g22
+    (x1,y3) : g31 (ground object)  and (x2,z3,y2) : g32
 
-        Inputs
+    Inputs
 
-        arg_str : is the list of strings : ['x,y','x,z,y']
-        bindings : list of bindings for each variable
-        g_list : is the list [ g_list[0], g_list[1]]
-        where g_list[0] is the dictionary g_list[0]
-           [(x1,y1)] = g11 ; [(x2,y2)] = g21 ; [(x1,y3)] = g31
-        and g_list[1] is the dictionary g_list[1]
-           [(x1,z1,y1)] = g12;[(x2,z2,y2)] = g2;[(x2,z3,y3)] = g32
+    arg_str : is the list of strings : ['x,y','x,z,y']
+    bindings : list of bindings for each variable
+    g_list : is the list [ g_list[0], g_list[1]]
+    where g_list[0] is the dictionary g_list[0]
+       [(x1,y1)] = g11 ; [(x2,y2)] = g21 ; [(x1,y3)] = g31
+    and g_list[1] is the dictionary g_list[1]
+       [(x1,z1,y1)] = g12;[(x2,z2,y2)] = g2;[(x2,z3,y3)] = g32
 
-        **Returns**
+    **Returns**
 
-        list_tuples:
-            List of joined ground tuples: [(x1,y1,z1), (x2,y2,z2), ...]
-        object: List of list of  ground objects for each operand
-           [[g11,g21], [g12,g22], ...]
+    list_tuples:
+        List of joined ground tuples: [(x1,y1,z1), (x2,y2,z2), ...]
+    object: List of list of  ground objects for each operand
+       [[g11,g21], [g12,g22], ...]
 
     """
     n_ops = len(g_list)
-    var_list = [g.split(', ') for g in arg_str]
+    var_list = [g.split(", ") for g in arg_str]
     _vars = set()
     var_map = {}
     var_count = 0
@@ -238,8 +251,7 @@ def _nested_loop_join_outer(g_list, arg_str, bindings, operands):
             if v in var_map2:
                 match_pos1.append(var_map1.index(v))
                 match_pos2.append(var_map2.index(v))
-        umatch_pos2 = [var_map2.index(v) for v in var_map2
-                       if v not in var_map1]
+        umatch_pos2 = [var_map2.index(v) for v in var_map2 if v not in var_map1]
 
         joined_vars = [v for v in var_map1]
         for v in var_map2:
@@ -269,9 +281,9 @@ def _nested_loop_join_outer(g_list, arg_str, bindings, operands):
             if a_ not in n_z_vars:
                 n_z_vars.append(a_)
 
-    if (set(all_vars) != set(n_z_vars)):
+    if set(all_vars) != set(n_z_vars):
         return None, None
-    reorder_pos = [None]*len(all_vars)
+    reorder_pos = [None] * len(all_vars)
     for i in range(len(n_z_vars)):
         reorder_pos[i] = all_vars.index(n_z_vars[i])
 
@@ -280,8 +292,13 @@ def _nested_loop_join_outer(g_list, arg_str, bindings, operands):
     for i in n_z_index[1:]:
         colllected_g_list_full = set()
         curr_to_merge = g_list[i]
-        match_pos1, match_pos2, umatch_pos2, joined_vars, scatter_pos2 = \
-            find_joined_vars(curr_map, var_remap[i])
+        (
+            match_pos1,
+            match_pos2,
+            umatch_pos2,
+            joined_vars,
+            scatter_pos2,
+        ) = find_joined_vars(curr_map, var_remap[i])
         for a1 in curr_merged:
             for a2 in curr_to_merge:
                 m1 = [a1[i] for i in match_pos1]
@@ -291,8 +308,8 @@ def _nested_loop_join_outer(g_list, arg_str, bindings, operands):
                     colllected_g_list_full.add(j1)
                 else:
                     j1 = tuple(list(a1) + [a2[k] for k in umatch_pos2])
-                    j2 = [None]*len(joined_vars)
-                    j2[0:len(a1)] = a1
+                    j2 = [None] * len(joined_vars)
+                    j2[0 : len(a1)] = a1
                     for i, j in enumerate(scatter_pos2):
                         j2[j] = a2[i]
                     j2 = tuple(j2)
@@ -307,7 +324,7 @@ def _nested_loop_join_outer(g_list, arg_str, bindings, operands):
         curr_op = copy.copy(g_list[i])
         for curr_tup in curr_merged:
             found = False
-            m1 = [None]*len(var_remap[i])
+            m1 = [None] * len(var_remap[i])
             for i_, r_ in enumerate(rev_index):
                 m1[rev_pos[i_]] = curr_tup[r_]
             m1 = tuple(m1)
@@ -335,31 +352,31 @@ def _nested_loop_join_outer(g_list, arg_str, bindings, operands):
 @torch.no_grad()
 def _nested_loop_join_outer_pruned(g_list, arg_str, bindings, operands):
     """
-        E.g  Join two Predicates P1(x,y) and P2(x,z,y) with groundings
-        (x1,y1) : g11 (ground object)  and (x1,z1,y1) : g12
-        (x2,y2) : g21 (ground object)  and (x2,z2,y2) : g22
-        (x1,y3) : g31 (ground object)  and (x2,z3,y2) : g32
+    E.g  Join two Predicates P1(x,y) and P2(x,z,y) with groundings
+    (x1,y1) : g11 (ground object)  and (x1,z1,y1) : g12
+    (x2,y2) : g21 (ground object)  and (x2,z2,y2) : g22
+    (x1,y3) : g31 (ground object)  and (x2,z3,y2) : g32
 
-        Inputs
+    Inputs
 
-        arg_str : is the list of strings : ['x,y','x,z,y']
-        bindings : list of bindings for each variable
-        g_list : is the list [ g_list[0], g_list[1]]
-        where g_list[0] is the dictionary g_list[0]
-           [(x1,y1)] = g11 ; [(x2,y2)] = g21 ; [(x1,y3)] = g31
-        and g_list[1] is the dictionary g_list[1]
-           [(x1,z1,y1)] = g12;[(x2,z2,y2)] = g2;[(x2,z3,y3)] = g32
+    arg_str : is the list of strings : ['x,y','x,z,y']
+    bindings : list of bindings for each variable
+    g_list : is the list [ g_list[0], g_list[1]]
+    where g_list[0] is the dictionary g_list[0]
+       [(x1,y1)] = g11 ; [(x2,y2)] = g21 ; [(x1,y3)] = g31
+    and g_list[1] is the dictionary g_list[1]
+       [(x1,z1,y1)] = g12;[(x2,z2,y2)] = g2;[(x2,z3,y3)] = g32
 
-        **Returns**
+    **Returns**
 
-        list_tuples:
-            List of joined ground tuples: [(x1,y1,z1), (x2,y2,z2), ...]
-        object: List of list of  ground objects for each operand
-           [[g11,g21], [g12,g22], ...]
+    list_tuples:
+        List of joined ground tuples: [(x1,y1,z1), (x2,y2,z2), ...]
+    object: List of list of  ground objects for each operand
+       [[g11,g21], [g12,g22], ...]
 
     """
     n_ops = len(g_list)
-    var_list = [g.split(', ') for g in arg_str]
+    var_list = [g.split(", ") for g in arg_str]
     _vars = set()
     var_map = {}
     var_count = 0
@@ -392,8 +409,7 @@ def _nested_loop_join_outer_pruned(g_list, arg_str, bindings, operands):
             if v in var_map2:
                 match_pos1.append(var_map1.index(v))
                 match_pos2.append(var_map2.index(v))
-        umatch_pos2 = [var_map2.index(v) for v in var_map2
-                       if v not in var_map1]
+        umatch_pos2 = [var_map2.index(v) for v in var_map2 if v not in var_map1]
 
         joined_vars = [v for v in var_map1]
         for v in var_map2:
@@ -426,9 +442,9 @@ def _nested_loop_join_outer_pruned(g_list, arg_str, bindings, operands):
             if a_ not in n_z_vars:
                 n_z_vars.append(a_)
 
-    if (set(all_vars) != set(n_z_vars)):
+    if set(all_vars) != set(n_z_vars):
         return None, None
-    reorder_pos = [None]*len(all_vars)
+    reorder_pos = [None] * len(all_vars)
     for i in range(len(n_z_vars)):
         reorder_pos[i] = all_vars.index(n_z_vars[i])
 
@@ -438,8 +454,13 @@ def _nested_loop_join_outer_pruned(g_list, arg_str, bindings, operands):
     for i in n_z_index[1:]:
         colllected_g_list_obj = {}
         curr_to_merge = g_list[i]
-        match_pos1, match_pos2, umatch_pos2, joined_vars, scatter_pos2 = \
-            find_joined_vars(curr_map, var_remap[i])
+        (
+            match_pos1,
+            match_pos2,
+            umatch_pos2,
+            joined_vars,
+            scatter_pos2,
+        ) = find_joined_vars(curr_map, var_remap[i])
         for a1 in curr_merged:
             for a2 in curr_to_merge:
                 m1 = [a1[i_] for i_ in match_pos1]
@@ -447,32 +468,36 @@ def _nested_loop_join_outer_pruned(g_list, arg_str, bindings, operands):
                 if m1 == m2:
                     j1 = tuple(list(a1) + [a2[k] for k in umatch_pos2])
                     if first_op:
-                        colllected_g_list_obj[j1] = \
-                            [curr_merged[a1]]+[curr_to_merge[a2]]
+                        colllected_g_list_obj[j1] = [curr_merged[a1]] + [
+                            curr_to_merge[a2]
+                        ]
                     else:
-                        colllected_g_list_obj[j1] = \
-                            curr_merged[a1]+[curr_to_merge[a2]]
+                        colllected_g_list_obj[j1] = curr_merged[a1] + [
+                            curr_to_merge[a2]
+                        ]
                 else:
                     j1 = tuple(list(a1) + [a2[k] for k in umatch_pos2])
-                    j2 = [None]*len(joined_vars)
-                    j2[0:len(a1)] = a1
+                    j2 = [None] * len(joined_vars)
+                    j2[0 : len(a1)] = a1
                     for i_, j_ in enumerate(scatter_pos2):
                         j2[j_] = a2[i_]
                     j2 = tuple(j2)
-                    colllected_g_list_obj[j1] = \
-                        [curr_merged[a1]]+[curr_to_merge[a2]]
-                    colllected_g_list_obj[j2] = \
-                        [curr_merged[a1]]+[curr_to_merge[a2]]
+                    colllected_g_list_obj[j1] = [curr_merged[a1]] + [curr_to_merge[a2]]
+                    colllected_g_list_obj[j2] = [curr_merged[a1]] + [curr_to_merge[a2]]
                     if first_op:
-                        colllected_g_list_obj[j1] = \
-                            [curr_merged[a1]]+[curr_to_merge[a2]]
-                        colllected_g_list_obj[j2] = \
-                            [curr_merged[a1]]+[curr_to_merge[a2]]
+                        colllected_g_list_obj[j1] = [curr_merged[a1]] + [
+                            curr_to_merge[a2]
+                        ]
+                        colllected_g_list_obj[j2] = [curr_merged[a1]] + [
+                            curr_to_merge[a2]
+                        ]
                     else:
-                        colllected_g_list_obj[j1] = \
-                            curr_merged[a1]+[curr_to_merge[a2]]
-                        colllected_g_list_obj[j2] = \
-                            curr_merged[a1]+[curr_to_merge[a2]]
+                        colllected_g_list_obj[j1] = curr_merged[a1] + [
+                            curr_to_merge[a2]
+                        ]
+                        colllected_g_list_obj[j2] = curr_merged[a1] + [
+                            curr_to_merge[a2]
+                        ]
         curr_map = joined_vars
         curr_merged = colllected_g_list_obj
         first_op = False
@@ -480,7 +505,7 @@ def _nested_loop_join_outer_pruned(g_list, arg_str, bindings, operands):
     if n_z_groundings:
         g_obj2 = {}
         for g in curr_merged:
-            g_ = [None]*len(g)
+            g_ = [None] * len(g)
             for i, a_ in enumerate(g):
                 g_[reorder_pos[i]] = a_
             g_ = tuple(g_)
@@ -489,9 +514,8 @@ def _nested_loop_join_outer_pruned(g_list, arg_str, bindings, operands):
             g_obj_indx = 0
             for i in range(n_ops):
                 if i not in n_z_index:
-                    rev_index, rev_pos = \
-                        find_rev_joined_pos(all_vars, var_remap[i])
-                    m1 = [None]*len(var_remap[i])
+                    rev_index, rev_pos = find_rev_joined_pos(all_vars, var_remap[i])
+                    m1 = [None] * len(var_remap[i])
                     for i_, r_ in enumerate(rev_index):
                         m1[rev_pos[i_]] = g_[r_]
                     m1 = tuple(m1)
@@ -522,31 +546,31 @@ def _nested_loop_join_outer_pruned(g_list, arg_str, bindings, operands):
 def _nested_loop_join_inner(g_list, arg_str, bindings, operands):
 
     """
-        E.g  Join two Predicates P1(x,y) and P2(x,z,y) with groundings
-        (x1,y1) : g11 (ground object)  and (x1,z1,y1) : g12
-        (x2,y2) : g21 (ground object)  and (x2,z2,y2) : g22
-        (x1,y3) : g31 (ground object)  and (x2,z3,y2) : g32
+    E.g  Join two Predicates P1(x,y) and P2(x,z,y) with groundings
+    (x1,y1) : g11 (ground object)  and (x1,z1,y1) : g12
+    (x2,y2) : g21 (ground object)  and (x2,z2,y2) : g22
+    (x1,y3) : g31 (ground object)  and (x2,z3,y2) : g32
 
-        Inputs
+    Inputs
 
-        arg_str : is the list of strings : ['x,y','x,z,y']
-        bindings : list of bindings for each variable
-        g_list : is the list [ g_list[0], g_list[1]]
-        where g_list[0] is the dictionary g_list[0]
-           [(x1,y1)] = g11 ; [(x2,y2)] = g21 ; [(x1,y3)] = g31
-        and g_list[1] is the dictionary g_list[1]
-           [(x1,z1,y1)] = g12;[(x2,z2,y2)] = g2;[(x2,z3,y3)] = g32
+    arg_str : is the list of strings : ['x,y','x,z,y']
+    bindings : list of bindings for each variable
+    g_list : is the list [ g_list[0], g_list[1]]
+    where g_list[0] is the dictionary g_list[0]
+       [(x1,y1)] = g11 ; [(x2,y2)] = g21 ; [(x1,y3)] = g31
+    and g_list[1] is the dictionary g_list[1]
+       [(x1,z1,y1)] = g12;[(x2,z2,y2)] = g2;[(x2,z3,y3)] = g32
 
-        **Returns**
+    **Returns**
 
-        list_tuples:
-            List of joined ground tuples: [(x1,y1,z1), (x2,y2,z2), ...]
-        object: List of list of  ground objects for each operand
-           [[g11,g21], [g12,g22], ...]
+    list_tuples:
+        List of joined ground tuples: [(x1,y1,z1), (x2,y2,z2), ...]
+    object: List of list of  ground objects for each operand
+       [[g11,g21], [g12,g22], ...]
 
     """
     n_ops = len(g_list)
-    var_list = [g.split(', ') for g in arg_str]
+    var_list = [g.split(", ") for g in arg_str]
     _vars = set()
     var_map = {}
     var_count = 0
@@ -579,8 +603,7 @@ def _nested_loop_join_inner(g_list, arg_str, bindings, operands):
             if v in var_map2:
                 match_pos1.append(var_map1.index(v))
                 match_pos2.append(var_map2.index(v))
-        umatch_pos2 = [var_map2.index(v) for v in var_map2
-                       if v not in var_map1]
+        umatch_pos2 = [var_map2.index(v) for v in var_map2 if v not in var_map1]
 
         joined_vars = [v for v in var_map1]
         for v in var_map2:
@@ -611,14 +634,14 @@ def _nested_loop_join_inner(g_list, arg_str, bindings, operands):
             if a_ not in n_z_vars:
                 n_z_vars.append(a_)
 
-    if (set(all_vars) != set(n_z_vars)):
+    if set(all_vars) != set(n_z_vars):
         curr_merged = g_list[0]
         g_obj = [None] * n_ops
         for i in range(n_ops):
             g_obj[i] = []
         return list(curr_merged.keys()), g_obj
 
-    reorder_pos = [None]*len(all_vars)
+    reorder_pos = [None] * len(all_vars)
     for i in range(len(n_z_vars)):
         reorder_pos[i] = all_vars.index(n_z_vars[i])
 
@@ -628,8 +651,9 @@ def _nested_loop_join_inner(g_list, arg_str, bindings, operands):
     for i in n_z_index[1:]:
         colllected_g_list_obj = {}
         curr_to_merge = g_list[i]
-        match_pos1, match_pos2, umatch_pos2, joined_vars, _ = \
-            find_joined_vars(curr_map, var_remap[i])
+        match_pos1, match_pos2, umatch_pos2, joined_vars, _ = find_joined_vars(
+            curr_map, var_remap[i]
+        )
         for a1 in curr_merged:
             for a2 in curr_to_merge:
                 m1 = [a1[i_] for i_ in match_pos1]
@@ -637,11 +661,13 @@ def _nested_loop_join_inner(g_list, arg_str, bindings, operands):
                 if m1 == m2:
                     j1 = tuple(list(a1) + [a2[k] for k in umatch_pos2])
                     if first_op:
-                        colllected_g_list_obj[j1] = \
-                            [curr_merged[a1]]+[curr_to_merge[a2]]
+                        colllected_g_list_obj[j1] = [curr_merged[a1]] + [
+                            curr_to_merge[a2]
+                        ]
                     else:
-                        colllected_g_list_obj[j1] = \
-                            curr_merged[a1]+[curr_to_merge[a2]]
+                        colllected_g_list_obj[j1] = curr_merged[a1] + [
+                            curr_to_merge[a2]
+                        ]
         curr_map = joined_vars
         curr_merged = colllected_g_list_obj
         first_op = False
@@ -649,7 +675,7 @@ def _nested_loop_join_inner(g_list, arg_str, bindings, operands):
     if n_z_groundings:
         g_obj2 = {}
         for g in curr_merged:
-            g_ = [None]*len(g)
+            g_ = [None] * len(g)
             for i, a_ in enumerate(g):
                 g_[reorder_pos[i]] = a_
             g_ = tuple(g_)
@@ -658,9 +684,8 @@ def _nested_loop_join_inner(g_list, arg_str, bindings, operands):
             g_obj_indx = 0
             for i in range(n_ops):
                 if i not in n_z_index:
-                    rev_index, rev_pos =\
-                        find_rev_joined_pos(all_vars, var_remap[i])
-                    m1 = [None]*len(var_remap[i])
+                    rev_index, rev_pos = find_rev_joined_pos(all_vars, var_remap[i])
+                    m1 = [None] * len(var_remap[i])
                     for i_, r_ in enumerate(rev_index):
                         m1[rev_pos[i_]] = g_[r_]
                     m1 = tuple(m1)
@@ -687,14 +712,20 @@ def _nested_loop_join_inner(g_list, arg_str, bindings, operands):
     return list(curr_merged.keys()), g_obj
 
 
-def is_grounding_in_bindings(self: _Formula,
-                             operand_idx: int,
-                             operand_grounding: _Grounding,
-                             ) -> bool:
-    return all(True if self.bindings[operand_idx][slot] == [None] else (
+def is_grounding_in_bindings(
+    self: _Formula,
+    operand_idx: int,
+    operand_grounding: _Grounding,
+) -> bool:
+    return all(
+        True
+        if self.bindings[operand_idx][slot] == [None]
+        else (
             operand_grounding.partial_grounding[slot]
-            in self.bindings[operand_idx][slot])
-            for slot in range(len(self.bindings[operand_idx])))
+            in self.bindings[operand_idx][slot]
+        )
+        for slot in range(len(self.bindings[operand_idx]))
+    )
 
 
 @torch.no_grad()
@@ -702,9 +733,10 @@ def _hash_join(operands: _Formula, groundings: Set) -> Set:
     """get groundings that appear in all children"""
 
     # limit grounding_table join to given groundings
-    grounding_tables = list({g: op.grounding_table[g]
-                            for g in groundings if g in op.grounding_table}
-                            for op in operands)
+    grounding_tables = list(
+        {g: op.grounding_table[g] for g in groundings if g in op.grounding_table}
+        for op in operands
+    )
     result = list()
     for g in groundings:
         if all(g in grounding_tables[slot] for slot in range(len(operands))):
@@ -714,8 +746,7 @@ def _hash_join(operands: _Formula, groundings: Set) -> Set:
 
 def _masked_negate(self: _Formula, bounds: torch.Tensor, dim: int = -2):
     """negate bounds where weights are negative"""
-    if hasattr(self.neuron, 'weights'):
-        result = bounds.where(
-            self.neuron.weights.data >= 0, negate_bounds(bounds, dim))
+    if hasattr(self.neuron, "weights"):
+        result = bounds.where(self.neuron.weights.data >= 0, negate_bounds(bounds, dim))
         return result
     return bounds

--- a/lnn/symbolic/_trace.py
+++ b/lnn/symbolic/_trace.py
@@ -4,22 +4,24 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
+
 def increment_param_history(self, **params):
-    if not hasattr(self, 'parameter_history'):
+    if not hasattr(self, "parameter_history"):
         self.parameter_history = {}
-    params = params.get('parameter_history')
+    params = params.get("parameter_history")
     for param in params:
-        split = param.split('.grad')
+        split = param.split(".grad")
         p = split[0]
         grad = False
         if len(split) == 2:
             grad = True
-        if ((params[p] is True or params[p] is self)
-                and hasattr(self.neuron, p)):
+        if (params[p] is True or params[p] is self) and hasattr(self.neuron, p):
             if param not in self.parameter_history:
                 self.parameter_history[param] = []
             attrib = getattr(self.neuron, p)
             val = attrib.grad if grad else attrib
             self.parameter_history[param].append(
-                val.tolist() if val is not None
-                else (attrib.clone().detach() * 0).tolist())
+                val.tolist()
+                if val is not None
+                else (attrib.clone().detach() * 0).tolist()
+            )

--- a/lnn/symbolic/axioms.py
+++ b/lnn/symbolic/axioms.py
@@ -22,5 +22,6 @@ def lifted_axioms() -> dict:
             q_1, r = formulae[1].operands
             if q_0 is q_1:
                 return p.Implies(r, world=World.AXIOM)
+
     result[hypothetical_syllogism] = 2
     return result

--- a/lnn/symbolic/logic.py
+++ b/lnn/symbolic/logic.py
@@ -34,6 +34,7 @@ class Variable:
     ```
 
     """
+
     def __init__(self, name: str, ctype: Optional[str] = None):
         self.name = name
         self.ctype = ctype
@@ -44,7 +45,7 @@ class Variable:
 
 
 # declaration to use hinting within the class definition
-_Grounding = TypeVar('_Grounding')
+_Grounding = TypeVar("_Grounding")
 
 
 class _Grounding(_utils.MultiInstance, _utils.UniqueNameAssumption):
@@ -79,16 +80,18 @@ class _Grounding(_utils.MultiInstance, _utils.UniqueNameAssumption):
             tuple of groundings for decomposition when constants given as tuple
 
     """
+
     def __init__(self, constants: Union[str, Tuple[str, ...]]):
         super().__init__(constants)
         self.name = str(constants)
         if isinstance(constants, tuple):
             self.grounding_arity = len(constants)
-            self.partial_grounding = tuple(map(
-                self._partial_grounding_from_str, constants))
+            self.partial_grounding = tuple(
+                map(self._partial_grounding_from_str, constants)
+            )
         else:
             self.grounding_arity = 1
-            self.partial_grounding = (self, )
+            self.partial_grounding = (self,)
 
     @classmethod
     def _partial_grounding_from_str(cls, constant: str) -> _Grounding:
@@ -98,8 +101,11 @@ class _Grounding(_utils.MultiInstance, _utils.UniqueNameAssumption):
     @classmethod
     def ground_by_groundings(cls, *grounding: _Grounding):
         r"""Reduce a tuple of groundings to a single grounding"""
-        return (grounding[0] if len(grounding) == 1
-                else cls.__class__(tuple(str(g) for g in grounding)))
+        return (
+            grounding[0]
+            if len(grounding) == 1
+            else cls.__class__(tuple(str(g) for g in grounding))
+        )
 
     def __len__(self) -> int:
         r"""Returns the length of the grounding arity"""
@@ -116,7 +122,7 @@ class _Grounding(_utils.MultiInstance, _utils.UniqueNameAssumption):
 
 
 # declaration to use hinting within the class definition
-_Formula = TypeVar('_Formula')
+_Formula = TypeVar("_Formula")
 
 
 class _Formula:
@@ -135,18 +141,23 @@ class _Formula:
         _Formula.unique_num.setdefault(self.__class__.__name__, 0)
         return self.__class__.__name__
 
-    def __init__(self,
-                 *formula: _Formula,
-                 name: Optional[str] = '',
-                 arity: int = None,
-                 world: World = World.OPEN,
-                 **kwds):
+    def __init__(
+        self,
+        *formula: _Formula,
+        name: Optional[str] = "",
+        arity: int = None,
+        world: World = World.OPEN,
+        **kwds,
+    ):
 
         # formula naming
-        self.name = name if name else (
-            f'{self.class_name}_{_Formula.unique_num[self.class_name]}')
+        self.name = (
+            name
+            if name
+            else (f"{self.class_name}_{_Formula.unique_num[self.class_name]}")
+        )
         _Formula.unique_num[self.class_name] += 1
-        self.join_method = kwds.get('join', Join.INNER)
+        self.join_method = kwds.get("join", Join.INNER)
 
         # construct edge and operand list for each formula
         self.edge_list = list()
@@ -156,7 +167,7 @@ class _Formula:
         self.arity = arity
 
         # inherit propositional, variables, and graphs
-        self.propositional = kwds.get('propositional')
+        self.propositional = kwds.get("propositional")
         self._inherit_from_subformulae(*formula)
 
         # formula truth world assumption
@@ -175,9 +186,7 @@ class _Formula:
     def set_propositional(self, propositional: bool) -> None:
         self.propositional = propositional
 
-    def _inherit_from_subformulae(self,
-                                  *subformula: Union[_Formula, Tuple]
-                                  ) -> None:
+    def _inherit_from_subformulae(self, *subformula: Union[_Formula, Tuple]) -> None:
         r"""
         _inherit_from_subformula(*Union[_Formulae, _Formula(*Variable)])
 
@@ -222,8 +231,9 @@ class _Formula:
 
         # inherit propositional flag from children
         if self.propositional is None:
-            self.set_propositional(False if any(
-                [not f.propositional for f in subformulae]) else True)
+            self.set_propositional(
+                False if any([not f.propositional for f in subformulae]) else True
+            )
 
         # inherit variables from children
         if not self.propositional and not isinstance(self, _LeafFormula):
@@ -232,8 +242,7 @@ class _Formula:
 
         # expand formula graph to include all subformulae
         if subformulae:
-            self.edge_list.extend([edge for f in subformulae
-                                   for edge in f.edge_list])
+            self.edge_list.extend([edge for f in subformulae for edge in f.edge_list])
 
     def _update_variables(self, *variables: Tuple[Variable, ...]) -> None:
         r"""
@@ -253,9 +262,12 @@ class _Formula:
         """
         self.operand_map = [None] * len(self.operand_vars)
         for op_index, op_vars in enumerate(self.var_remap):
-            op_map = [var_index for var_op in self.var_remap[op_index]
-                      for var_index, var in enumerate(self.unique_vars)
-                      if var == var_op]
+            op_map = [
+                var_index
+                for var_op in self.var_remap[op_index]
+                for var_index, var in enumerate(self.unique_vars)
+                if var == var_op
+            ]
             self.operand_map[op_index] = tuple(op_map)
 
     def _set_world(self, world: World) -> None:
@@ -264,16 +276,14 @@ class _Formula:
         self.neuron.set_world(world)
 
     @staticmethod
-    def _is_grounded(groundings: Union[_Grounding,
-                                       str,
-                                       Tuple[str, ...]]
-                     ) -> bool:
+    def _is_grounded(groundings: Union[_Grounding, str, Tuple[str, ...]]) -> bool:
         return isinstance(groundings, _Grounding)
 
-    def _ground(self,
-                grounding: Union[_Grounding, str, Tuple[str, ...]],
-                arity_match: bool = True
-                ) -> _Grounding:
+    def _ground(
+        self,
+        grounding: Union[_Grounding, str, Tuple[str, ...]],
+        arity_match: bool = True,
+    ) -> _Grounding:
         r"""returns a single grounded object
 
         **Example**
@@ -299,17 +309,20 @@ class _Formula:
         if isinstance(grounding, tuple):
             if not all([type(g) in [str, None] for g in grounding]):
                 raise Exception(
-                    'expected groundings as tuple of str for num_unique_vars '
-                    f' > 1, received {type(grounding)} {grounding}')
+                    "expected groundings as tuple of str for num_unique_vars "
+                    f" > 1, received {type(grounding)} {grounding}"
+                )
             if len(grounding) != self.num_unique_vars and arity_match:
                 raise Exception(
-                    'expected grounding length to be of '
-                    f'arity {self.num_unique_vars}, received {grounding}')
+                    "expected grounding length to be of "
+                    f"arity {self.num_unique_vars}, received {grounding}"
+                )
         else:
             if self.num_unique_vars != 1 and arity_match:
                 raise Exception(
-                    f'{self} received str as grounding, expected grounding '
-                    f'({grounding}) as a tuple of len {self.num_unique_vars}')
+                    f"{self} received str as grounding, expected grounding "
+                    f"({grounding}) as a tuple of len {self.num_unique_vars}"
+                )
         return _Grounding(grounding)
 
     def _add_groundings(self, *groundings: _Grounding) -> None:
@@ -339,13 +352,13 @@ class _Formula:
         - instead use `model.add_facts('node': Fact)`
 
         """
-        missing_groundings = {g for g in groundings
-                              if g not in self.grounding_table}
+        missing_groundings = {g for g in groundings if g not in self.grounding_table}
         if len(missing_groundings) == 0:
             return
         table_rows = self.neuron.extend_groundings(len(missing_groundings))
         self.grounding_table.update(
-            {g: table_rows[i] for i, g in enumerate(missing_groundings)})
+            {g: table_rows[i] for i, g in enumerate(missing_groundings)}
+        )
 
     def _add_facts(self, facts: Union[Fact, Tuple, Set, Dict]) -> None:
         r"""Populate formula with fact
@@ -390,18 +403,19 @@ class _Formula:
                 self._add_groundings(*groundings)
 
                 # set facts for all groundings
-                table_facts = {
-                    self.grounding_table[g]: facts[g] for g in groundings}
+                table_facts = {self.grounding_table[g]: facts[g] for g in groundings}
             elif isinstance(facts, set):  # broadcast facts across groundings
                 table_facts = facts
             else:
-                raise Exception('FOL facts should be from [dict, set], '
-                                f'"{self}" received {type(facts)}')
+                raise Exception(
+                    "FOL facts should be from [dict, set], "
+                    f'"{self}" received {type(facts)}'
+                )
             self.neuron.add_facts(table_facts, update_leaves=True)
 
-    def get_facts(self,
-                  *groundings: Union[str, Tuple[str, ...], _Grounding]
-                  ) -> torch.Tensor:
+    def get_facts(
+        self, *groundings: Union[str, Tuple[str, ...], _Grounding]
+    ) -> torch.Tensor:
         r"""returns bounds_table slices
 
         if groundings is None, the whole table will return
@@ -409,8 +423,7 @@ class _Formula:
         """
         if self.propositional or len(groundings) == 0:
             return self.neuron.get_facts()
-        table_rows = list(self.grounding_table.get(self._ground(g))
-                          for g in groundings)
+        table_rows = list(self.grounding_table.get(self._ground(g)) for g in groundings)
         result = self.neuron.get_facts(table_rows)
         return result
 
@@ -418,13 +431,10 @@ class _Formula:
         r"""returns labels if no groundings else tuple of given bounds"""
         if self.propositional or len(groundings) == 0:
             return self.labels
-        result = torch.stack(
-            [self.labels.get(self._ground(g)) for g in groundings])
+        result = torch.stack([self.labels.get(self._ground(g)) for g in groundings])
         return result[0] if len(groundings) == 1 else result
 
-    def _add_labels(self,
-                    labels: Union[Fact, Tuple[str, ...], Set, Dict]
-                    ) -> None:
+    def _add_labels(self, labels: Union[Fact, Tuple[str, ...], Set, Dict]) -> None:
         r"""Populate labels with fact
 
         Facts given in bool, tuple or None, assumes a propositional formula.
@@ -448,32 +458,32 @@ class _Formula:
             self.labels = _utils.fact_to_bounds(labels, True)
 
         else:  # FOL labels
-            if not hasattr(self, 'labels'):
+            if not hasattr(self, "labels"):
                 self.labels = dict()
             if isinstance(labels, dict):  # labels given per grounding
                 for g in tuple(labels.keys()):
                     # set labels for groundings, replace str keys -> Groundings
                     self.labels[self._ground(g)] = _utils.fact_to_bounds(
-                        labels.pop(g), True)
+                        labels.pop(g), True
+                    )
             else:
-                raise Exception('FOL facts should be from [dict, set], '
-                                f'"{self}" received {type(labels)}')
+                raise Exception(
+                    "FOL facts should be from [dict, set], "
+                    f'"{self}" received {type(labels)}'
+                )
 
     @property
     def groundings(self) -> Set:
         return {g for g in self.grounding_table}
 
-    def state(self,
-              groundings: Union[str,
-                                Tuple[str, ...],
-                                List[str],
-                                List[Tuple[str, ...]]] = None,
-              to_bool: bool = False,
-              bounds: torch.Tensor = None
-              ) -> Union[torch.Tensor,
-                         Dict[Union[str,
-                                    Tuple[str, ...]],
-                              torch.Tensor]]:
+    def state(
+        self,
+        groundings: Union[
+            str, Tuple[str, ...], List[str], List[Tuple[str, ...]]
+        ] = None,
+        to_bool: bool = False,
+        bounds: torch.Tensor = None,
+    ) -> Union[torch.Tensor, Dict[Union[str, Tuple[str, ...]], torch.Tensor]]:
         r"""returns the state of a single grounded fact
 
         if to_bool flag is True, will map classical Facts to bool:
@@ -491,25 +501,28 @@ class _Formula:
         else:
             if bounds is None:
                 if groundings is None or isinstance(groundings, list):
-                    result = {str(g): self.state(g)
-                              for g in (self.grounding_table
-                              if groundings is None else groundings)}
+                    result = {
+                        str(g): self.state(g)
+                        for g in (
+                            self.grounding_table if groundings is None else groundings
+                        )
+                    }
                     return result
                 groundings = self._ground(groundings)
                 bounds = self.get_facts(groundings)
             if len(bounds) == 0:
-                raise LookupError(
-                    f'grounding {groundings} not found in {str(self)}')
+                raise LookupError(f"grounding {groundings} not found in {str(self)}")
             result = self.neuron.state(bounds[None, :])[0]
         result = _utils.node_state(result)
         return utils.fact_to_bool(result) if to_bool else result
 
-    def print(self,
-              header_len: int = 50,
-              roundoff: int = 5,
-              params: bool = False,
-              grads: bool = False
-              ) -> None:
+    def print(
+        self,
+        header_len: int = 50,
+        roundoff: int = 5,
+        params: bool = False,
+        grads: bool = False,
+    ) -> None:
         r"""
         print the state of the formula
 
@@ -538,102 +551,129 @@ class _Formula:
         ```
 
         """
+
         def state_wrapper(grounding: _Grounding):
-            return (f"'{grounding}'" if grounding.grounding_arity == 1
-                    else f"{grounding}")
+            return (
+                f"'{grounding}'" if grounding.grounding_arity == 1 else f"{grounding}"
+            )
 
         def round_bounds(grounding=None):
-            return tuple([round(r, roundoff)
-                          for r in (self.get_facts(grounding)
-                                    if self.propositional else
-                                    self.get_facts(grounding)[0]).tolist()])
+            return tuple(
+                [
+                    round(r, roundoff)
+                    for r in (
+                        self.get_facts(grounding)
+                        if self.propositional
+                        else self.get_facts(grounding)[0]
+                    ).tolist()
+                ]
+            )
 
-        header = (f'{self.world.name:<6} '
-                  f'{self.__class__.__name__}: '
-                  f'{str(self)}')
+        header = f"{self.world.name:<6} " f"{self.__class__.__name__}: " f"{str(self)}"
         if params:
             params = dict()
             for name, symbol in _utils.param_symbols.items():
                 if hasattr(self.neuron, name):
                     val = getattr(self.neuron, name)
-                    params[symbol] = (
-                        f'{np.around(val.tolist(), roundoff)}'
-                        + (f' grads {np.around(val.grad.tolist(), roundoff)}'
-                           if grads and val.grad is not None else ''))
-            params = ('params  ' + ',  '.join(
-                [f'{k}: {v}' for k, v in params.items()]))
+                    params[symbol] = f"{np.around(val.tolist(), roundoff)}" + (
+                        f" grads {np.around(val.grad.tolist(), roundoff)}"
+                        if grads and val.grad is not None
+                        else ""
+                    )
+            params = "params  " + ",  ".join([f"{k}: {v}" for k, v in params.items()])
         else:
-            params = ''
+            params = ""
 
         # extract variables
-        var_str = '' if not (
-                hasattr(self, 'unique_vars') and self.unique_vars) else (
-            str(tuple([str(v) for v in self.unique_vars])) if (
-                    len(self.unique_vars) > 1) else (
-                str(f'({self.unique_vars[0]})')))
+        var_str = (
+            ""
+            if not (hasattr(self, "unique_vars") and self.unique_vars)
+            else (
+                str(tuple([str(v) for v in self.unique_vars]))
+                if (len(self.unique_vars) > 1)
+                else (str(f"({self.unique_vars[0]})"))
+            )
+        )
 
         # print propositional node - single bounds
         if self.propositional:
             states = (
                 f'{" ".join([header, var_str]):<{header_len}} '
-                f'{self.state().name:>13} '
-                f'{round_bounds()}\n'
-                f'{params}')
+                f"{self.state().name:>13} "
+                f"{round_bounds()}\n"
+                f"{params}"
+            )
             print(states)
 
         # print FOL node - table of bounds
         else:
-            facts = [''] if self.grounding_table is None else (
-                    [(f'{state_wrapper(g):{header_len}} '
-                      f'{self.state(g).name:>13} '
-                      f'{round_bounds(g)}\n')
-                     for g in self.grounding_table])
-            var_str = '' if not (
-                hasattr(self, 'unique_vars') and self.unique_vars) else (
-                    str(tuple([str(v) for v in self.unique_vars])) if (
-                        len(self.unique_vars) > 1) else (
-                            str(f'({self.unique_vars[0]})')))
+            facts = (
+                [""]
+                if self.grounding_table is None
+                else (
+                    [
+                        (
+                            f"{state_wrapper(g):{header_len}} "
+                            f"{self.state(g).name:>13} "
+                            f"{round_bounds(g)}\n"
+                        )
+                        for g in self.grounding_table
+                    ]
+                )
+            )
+            var_str = (
+                ""
+                if not (hasattr(self, "unique_vars") and self.unique_vars)
+                else (
+                    str(tuple([str(v) for v in self.unique_vars]))
+                    if (len(self.unique_vars) > 1)
+                    else (str(f"({self.unique_vars[0]})"))
+                )
+            )
 
             binder = list()
             for i, op in enumerate(self.operands):
-                if (var_str
-                        and not self.propositional
-                        and self._has_bindings(i)):
-                    binder.append(f'{op} ({self.binding_str[i]})')
-            bind_str = ('\nBindings: ' + ', '.join(binder)) if binder else ''
-            header = f'{header}{var_str} {bind_str}'
-            params = (f'\n{params}' if params else '')
-            header = f'{header}{params}'
-            print(f'{header}\n' + ''.join(facts))
+                if var_str and not self.propositional and self._has_bindings(i):
+                    binder.append(f"{op} ({self.binding_str[i]})")
+            bind_str = ("\nBindings: " + ", ".join(binder)) if binder else ""
+            header = f"{header}{var_str} {bind_str}"
+            params = f"\n{params}" if params else ""
+            header = f"{header}{params}"
+            print(f"{header}\n" + "".join(facts))
 
     def flush(self) -> None:
         r"""set all facts in formula to 'Unknown'"""
         self.neuron.flush()
 
-    def is_contradiction(self,
-                         bounds: torch.Tensor = None
-                         ) -> torch.BoolTensor:
+    def is_contradiction(self, bounds: torch.Tensor = None) -> torch.BoolTensor:
         r"""check if bounds are in contradiction"""
         return self.neuron.is_contradiction(bounds)
 
     def _has_bindings(self, slot: int = None) -> bool:
         r"""Returns True if Formula has any bindings"""
         if isinstance(slot, int):
-            return True if any([self.bindings[slot][i][j]
-                                for i in range(len(self.bindings[slot]))
-                                for j in range(len(self.bindings[slot][i]))]
-                               ) else False
-        return any([self._has_bindings(i)
-                    for i in range(len(self.bindings))])
+            return (
+                True
+                if any(
+                    [
+                        self.bindings[slot][i][j]
+                        for i in range(len(self.bindings[slot]))
+                        for j in range(len(self.bindings[slot][i]))
+                    ]
+                )
+                else False
+            )
+        return any([self._has_bindings(i) for i in range(len(self.bindings))])
 
-    def __call__(self,
-                 *variables: Union[Variable,
-                                   Tuple[Variable, Union[str, List[str]]]]
-                 ) -> Tuple[_Formula,
-                            List[Union[Variable, None]],
-                            Tuple[List[Union[Variable, None]], ...],
-                            Tuple[Union[_Grounding, None], ...],
-                            str]:
+    def __call__(
+        self, *variables: Union[Variable, Tuple[Variable, Union[str, List[str]]]]
+    ) -> Tuple[
+        _Formula,
+        List[Union[Variable, None]],
+        Tuple[List[Union[Variable, None]], ...],
+        Tuple[Union[_Grounding, None], ...],
+        str,
+    ]:
         r"""variable remapping between operator and operand variables
 
         **Example**
@@ -660,8 +700,9 @@ class _Formula:
         """
         if len(variables) != self.num_unique_vars:
             raise Exception(
-                f'{self} variables length ({len(variables)}) must be the same '
-                f'length as `num_unique_vars` ({self.num_unique_vars})')
+                f"{self} variables length ({len(variables)}) must be the same "
+                f"length as `num_unique_vars` ({self.num_unique_vars})"
+            )
         bindings = list()
         _variables = list()  # variables to return
         binding_str = list()
@@ -669,29 +710,27 @@ class _Formula:
             if isinstance(v, tuple):
                 if not isinstance(v[0], Variable):
                     raise Exception(
-                        'expected a Variable for first tuple input, received '
-                        f'{[type(v[0]), v[0]]}')
+                        "expected a Variable for first tuple input, received "
+                        f"{[type(v[0]), v[0]]}"
+                    )
                 _variables.append(v[0])
-                binding_str.append(f'{v[0]}: {v[1]}')
+                binding_str.append(f"{v[0]}: {v[1]}")
                 if isinstance(v[1], list):  # Pred(x, ['str_1', ...]))
-                    bindings.append([self._ground(g, arity_match=False)
-                                     for g in v[1]])
+                    bindings.append([self._ground(g, arity_match=False) for g in v[1]])
                 elif isinstance(v[1], str):  # Pred(x, 'str_1')
                     bindings.append([self._ground(v[1], arity_match=False)])
                 else:
-                    raise Exception('bindings expected from [str, List(str)],'
-                                    f' received {type(v[1]), v[1]}')
+                    raise Exception(
+                        "bindings expected from [str, List(str)],"
+                        f" received {type(v[1]), v[1]}"
+                    )
             else:
                 bindings.append([None])
                 _variables.append(v)
-                binding_str.append(f'{v}')
-            binding_str = [', '.join(binding_str)]
-        binding_str = ', '.join(binding_str)
-        return (self,
-                self.variables,
-                tuple(_variables),
-                tuple(bindings),
-                binding_str)
+                binding_str.append(f"{v}")
+            binding_str = [", ".join(binding_str)]
+        binding_str = ", ".join(binding_str)
+        return (self, self.variables, tuple(_variables), tuple(bindings), binding_str)
 
     def __str__(self) -> str:
         return self.name
@@ -706,23 +745,22 @@ class _Formula:
     def named_parameters(self) -> Iterator[Tuple[str, torch.Tensor]]:
         yield from self.neuron.named_parameters()
 
-    def params(self,
-               *params: str,
-               detach: bool = False
-               ) -> Union[torch.Tensor, List[torch.Tensor]]:
+    def params(
+        self, *params: str, detach: bool = False
+    ) -> Union[torch.Tensor, List[torch.Tensor]]:
         result = list()
         for param in params:
             if param in dict(self.neuron.named_parameters()):
                 result.append(
                     getattr(self.neuron, param).clone().detach()
-                    if detach else getattr(self.neuron, param))
+                    if detach
+                    else getattr(self.neuron, param)
+                )
             else:
-                raise ValueError(f'{self} has no attribute: {param}')
+                raise ValueError(f"{self} has no attribute: {param}")
         return result[0] if len(params) == 1 else result
 
-    def contradiction_loss(self,
-                           coeff: float = None
-                           ) -> torch.Tensor:
+    def contradiction_loss(self, coeff: float = None) -> torch.Tensor:
         r"""Contradiction loss"""
         if coeff is None:
             coeff = 1
@@ -730,9 +768,7 @@ class _Formula:
         x = bounds[..., 0] - bounds[..., 1]
         return (self.is_contradiction() * coeff * x).sum()
 
-    def uncertainty_loss(self,
-                         coeff: float = None
-                         ) -> torch.Tensor:
+    def uncertainty_loss(self, coeff: float = None) -> torch.Tensor:
         r"""Uncertainty loss"""
         if coeff is None:
             coeff = 0
@@ -740,16 +776,16 @@ class _Formula:
         x = bounds[..., 1] - bounds[..., 0]
         return (self.is_contradiction().logical_not() * coeff * x).sum()
 
-    def supervised_loss(self,
-                        coeff: float = None
-                        ) -> Union[None, torch.Tensor]:
+    def supervised_loss(self, coeff: float = None) -> Union[None, torch.Tensor]:
         r"""supervised loss"""
         if coeff is None:
             coeff = 1
         loss = torch.nn.MSELoss()
-        if (not hasattr(self, 'labels')
-                or (self.propositional and not self.labels.numel())
-                or (not self.propositional and not self.labels)):
+        if (
+            not hasattr(self, "labels")
+            or (self.propositional and not self.labels.numel())
+            or (not self.propositional and not self.labels)
+        ):
             return
         labels = self.get_labels()
         if self.propositional:
@@ -757,8 +793,7 @@ class _Formula:
         groundings = [g for g in labels if g in self.grounding_table]
         if len(groundings) == 0:
             return
-        return coeff * loss(
-            self.get_facts(*groundings), self.get_labels(*groundings))
+        return coeff * loss(self.get_facts(*groundings), self.get_labels(*groundings))
 
     def reset_bounds(self) -> None:
         self.neuron.reset_bounds()
@@ -769,7 +804,7 @@ class _Formula:
     increment_param_history = _trace.increment_param_history
 
     def is_unweighted(self) -> bool:
-        bias, weights = self.params('bias', 'weights')
+        bias, weights = self.params("bias", "weights")
         return all([bias == w for w in weights])
 
     @property
@@ -779,7 +814,7 @@ class _Formula:
     @staticmethod
     def _formula_name(*formulae: _Formula, connective: str) -> str:
         r"""Come up with a name for input formula(e)"""
-        return '(' + f' {connective} '.join([f.name for f in formulae]) + ')'
+        return "(" + f" {connective} ".join([f.name for f in formulae]) + ")"
 
     @staticmethod
     def _formula_vars(*formulae: _Formula) -> List[Union[_Formula, Tuple]]:
@@ -787,49 +822,51 @@ class _Formula:
         Returns a list of formulae as wither called (when predicates)
         or uncalled as connectives
         """
-        variables = list(Variable(f"x{i}") for i in range(
-            max([f.arity for f in formulae])))
-        return [f(*variables[:f.arity]) if not f.propositional else f
-                for f in formulae]
+        variables = list(
+            Variable(f"x{i}") for i in range(max([f.arity for f in formulae]))
+        )
+        return [
+            f(*variables[: f.arity]) if not f.propositional else f for f in formulae
+        ]
 
     # declaration to use hinting within the function definition
-    Not = TypeVar('Not')
+    Not = TypeVar("Not")
 
     def Not(self, **kwds) -> Not:
-        if 'name' not in kwds:
-            kwds['name'] = f'¬({self.name})'
+        if "name" not in kwds:
+            kwds["name"] = f"¬({self.name})"
         return Not(*self._formula_vars(self), **kwds)
 
     # declaration to use hinting within the function definition
-    And = TypeVar('And')
+    And = TypeVar("And")
 
     def And(self, *formulae: _Formula, **kwds) -> And:
-        if 'name' not in kwds:
-            kwds['name'] = self._formula_name(self, *formulae, connective='∧')
+        if "name" not in kwds:
+            kwds["name"] = self._formula_name(self, *formulae, connective="∧")
         return And(*self._formula_vars(self), **kwds)
 
     # declaration to use hinting within the function definition
-    Or = TypeVar('Or')
+    Or = TypeVar("Or")
 
     def Or(self, *formulae: _Formula, **kwds) -> Or:
-        if 'name' not in kwds:
-            kwds['name'] = self._formula_name(self, *formulae, connective='∨')
+        if "name" not in kwds:
+            kwds["name"] = self._formula_name(self, *formulae, connective="∨")
         return Or(*self._formula_vars(self, *formulae), **kwds)
 
     # declaration to use hinting within the function definition
-    Implies = TypeVar('Implies')
+    Implies = TypeVar("Implies")
 
     def Implies(self, formula: _Formula, **kwds) -> Implies:
-        if 'name' not in kwds:
-            kwds['name'] = self._formula_name(self, formula, connective='→')
+        if "name" not in kwds:
+            kwds["name"] = self._formula_name(self, formula, connective="→")
         return Implies(*self._formula_vars(self, formula), **kwds)
 
     # declaration to use hinting within the function definition
-    Bidirectional = TypeVar('Bidirectional')
+    Bidirectional = TypeVar("Bidirectional")
 
     def Bidirectional(self, formula: _Formula, **kwds) -> Bidirectional:
-        if 'name' not in kwds:
-            kwds['name'] = self._formula_name(self, formula, connective='↔')
+        if "name" not in kwds:
+            kwds["name"] = self._formula_name(self, formula, connective="↔")
         return Bidirectional(*self._formula_vars(self, formula), **kwds)
 
 
@@ -840,10 +877,12 @@ class _LeafFormula(_Formula):
         uses the _NodeActivation accordingly
 
     """
+
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
         self.neuron = _NodeActivation()(
-            self.propositional, self.world, **kwds.get('neuron', {}))
+            self.propositional, self.world, **kwds.get("neuron", {})
+        )
 
 
 class Proposition(_LeafFormula):
@@ -863,9 +902,8 @@ class Proposition(_LeafFormula):
     ```
 
     """
-    def __init__(self,
-                 name: Optional[str] = '',
-                 **kwds):
+
+    def __init__(self, name: Optional[str] = "", **kwds):
         super().__init__(name=name, arity=1, propositional=True, **kwds)
 
     def _add_facts(self, fact: Fact) -> None:
@@ -900,16 +938,12 @@ class Predicate(_LeafFormula):
     ```
 
     """
-    def __init__(self,
-                 name: Optional[str] = '',
-                 arity: int = 1,
-                 **kwds):
+
+    def __init__(self, name: Optional[str] = "", arity: int = 1, **kwds):
         if arity is None:
-            raise Exception(
-                f"arity expected as int > 0, received {arity}")
+            raise Exception(f"arity expected as int > 0, received {arity}")
         super().__init__(name=name, arity=arity, propositional=False, **kwds)
-        self._update_variables(
-            tuple(Variable(f"x{i}") for i in range(self.arity)))
+        self._update_variables(tuple(Variable(f"x{i}") for i in range(self.arity)))
 
     def _add_facts(self, facts: Union[dict, set]) -> None:
         r"""Populate predicate with facts
@@ -926,53 +960,57 @@ class Predicate(_LeafFormula):
 
 
 class _ConnectiveFormula(_Formula):
-    def __init__(self,
-                 *formula: _Formula,
-                 **kwds):
+    def __init__(self, *formula: _Formula, **kwds):
         super().__init__(*formula, **kwds)
 
 
 class _ConnectiveNeuron(_ConnectiveFormula):
     def __init__(self, *formula, **kwds):
         super().__init__(*formula, **kwds)
-        self.neuron = _NeuralActivation(
-            kwds.get('neuron', {}).get('type'))(
-                self.propositional, self.arity, self.world,
-                **kwds.get('neuron', {}))
+        self.neuron = _NeuralActivation(kwds.get("neuron", {}).get("type"))(
+            self.propositional, self.arity, self.world, **kwds.get("neuron", {})
+        )
         self.func = self.neuron.function(
-            self.__class__.__name__, direction=Direction.UPWARD)
+            self.__class__.__name__, direction=Direction.UPWARD
+        )
         self.func_inv = self.neuron.function(
-            self.__class__.__name__, direction=Direction.DOWNWARD)
+            self.__class__.__name__, direction=Direction.DOWNWARD
+        )
 
-    def upward(self,
-               groundings: Set[Union[str, Tuple[str, ...]]] = None,
-               **kwds
-               ) -> Union[torch.Tensor, None]:
+    def upward(
+        self, groundings: Set[Union[str, Tuple[str, ...]]] = None, **kwds
+    ) -> Union[torch.Tensor, None]:
         upward_bounds = _gm.upward_bounds(self, self.operands, groundings)
         if upward_bounds is None:  # contradiction arresting
             return
         input_bounds, groundings = upward_bounds
-        grounding_rows = None if self.propositional else (
-            self.grounding_table.values() if groundings is None
-            else [self.grounding_table.get(g) for g in groundings])
-        result = self.neuron.aggregate_bounds(
-            grounding_rows, self.func(input_bounds))
+        grounding_rows = (
+            None
+            if self.propositional
+            else (
+                self.grounding_table.values()
+                if groundings is None
+                else [self.grounding_table.get(g) for g in groundings]
+            )
+        )
+        result = self.neuron.aggregate_bounds(grounding_rows, self.func(input_bounds))
         return result
 
-    def downward(self,
-                 index: int = None,
-                 groundings: Set[Union[str, Tuple[str, ...]]] = None,
-                 **kwds
-                 ) -> Union[torch.Tensor, None]:
+    def downward(
+        self,
+        index: int = None,
+        groundings: Set[Union[str, Tuple[str, ...]]] = None,
+        **kwds,
+    ) -> Union[torch.Tensor, None]:
         operands = tuple(self.operands)
-        downward_bounds = _gm.downward_bounds(
-            self, operands, groundings)
+        downward_bounds = _gm.downward_bounds(self, operands, groundings)
         if downward_bounds is None:  # contradiction arresting
             return
         out_bounds, input_bounds, groundings = downward_bounds
         new_bounds = self.func_inv(out_bounds, input_bounds)
-        op_indices = enumerate(operands) if index is None else (
-            [(index, operands[index])])
+        op_indices = (
+            enumerate(operands) if index is None else ([(index, operands[index])])
+        )
         result = 0
         for op_index, op in op_indices:
             if op.propositional:
@@ -983,19 +1021,20 @@ class _ConnectiveNeuron(_ConnectiveFormula):
                 else:
                     op_grounding_rows = [None] * len(groundings)
                     for g_i, g in enumerate(groundings):
-                        op_g = [str(g.partial_grounding[slot])
-                                for slot in self.operand_map[op_index]]
-                        op_g = _Grounding(tuple(op_g) if len(op_g) > 1
-                                          else op_g[0])
+                        op_g = [
+                            str(g.partial_grounding[slot])
+                            for slot in self.operand_map[op_index]
+                        ]
+                        op_g = _Grounding(tuple(op_g) if len(op_g) > 1 else op_g[0])
                         op_grounding_rows[g_i] = op.grounding_table.get(op_g)
             result = result + op.neuron.aggregate_bounds(
-                op_grounding_rows, new_bounds[..., op_index])
+                op_grounding_rows, new_bounds[..., op_index]
+            )
         return result
 
-    def logical_loss(self,
-                     coeff: float = None,
-                     slacks: Union[bool, float] = None
-                     ) -> torch.Tensor:
+    def logical_loss(
+        self, coeff: float = None, slacks: Union[bool, float] = None
+    ) -> torch.Tensor:
         r"""Logical loss to create a loss on logical constraint violation
 
         Assumes a soft logic computation and calculates the loss on constraints
@@ -1006,16 +1045,14 @@ class _ConnectiveNeuron(_ConnectiveFormula):
         definition of logic
 
         """
-        a, b, w = self.params('alpha', 'bias', 'weights')
-        T, F = a, 1-a
+        a, b, w = self.params("alpha", "bias", "weights")
+        T, F = a, 1 - a
         coeff = 1 if coeff is None else coeff
         if isinstance(self, And):
             TRUE = b - (w * (1 - T)).sum()
             FALSE = b - (w * (1 - F))
-            true_hinge = torch.where(
-                TRUE < T, T - TRUE, TRUE * 0)
-            false_hinge = torch.where(
-                FALSE > F, FALSE - F, FALSE * 0)
+            true_hinge = torch.where(TRUE < T, T - TRUE, TRUE * 0)
+            false_hinge = torch.where(FALSE > F, FALSE - F, FALSE * 0)
             if slacks:
                 if slacks is True:
                     slacks_false = false_hinge * (false_hinge > 0)
@@ -1024,43 +1061,44 @@ class _ConnectiveNeuron(_ConnectiveFormula):
                     true_hinge -= slacks_true
                     self.neuron.slacks = (
                         slacks_true.detach().clone(),
-                        slacks_false.detach().clone())
+                        slacks_false.detach().clone(),
+                    )
                 else:
                     false_hinge -= slacks
             self.neuron.feasibility = (
                 true_hinge.detach().clone(),
-                false_hinge.detach().clone())
+                false_hinge.detach().clone(),
+            )
 
         elif isinstance(self, Or):
             TRUE = 1 - b + (w * T)
             FALSE = 1 - b + (w * F).sum()
-            true_hinge = torch.where(
-                TRUE < T, T - TRUE, TRUE * 0).sum()
-            false_hinge = torch.where(
-                FALSE > F, FALSE - F, FALSE * 0)
+            true_hinge = torch.where(TRUE < T, T - TRUE, TRUE * 0).sum()
+            false_hinge = torch.where(FALSE > F, FALSE - F, FALSE * 0)
         elif isinstance(self, Implies):
             TRUE = 1 - b + (w * T)  # T = 1-F for x and T for y
             FALSE = 1 - b + (w[0] * (1 - T)) + (w[1] * F)
-            true_hinge = torch.where(
-                TRUE < T, T - TRUE, TRUE * 0).sum()
-            false_hinge = torch.where(
-                FALSE > F, FALSE - F, FALSE * 0)
+            true_hinge = torch.where(TRUE < T, T - TRUE, TRUE * 0).sum()
+            false_hinge = torch.where(FALSE > F, FALSE - F, FALSE * 0)
         result = (true_hinge.square() + false_hinge.square()).sum()
         return coeff * result
 
 
 class _BinaryNeuron(_ConnectiveNeuron):
     r"""Restrict neurons to 2 inputs"""
+
     def __init__(self, *formula, **kwds):
         if len(formula) != 2:
             raise Exception(
-                'Binary neurons expect 2 formulae as inputs, received '
-                f'{len(formula)}')
+                "Binary neurons expect 2 formulae as inputs, received "
+                f"{len(formula)}"
+            )
         super().__init__(*formula, arity=2, **kwds)
 
 
 class _NAryNeuron(_ConnectiveNeuron):
     r"""N-ary connective neuron"""
+
     def __init__(self, *formula, **kwds):
         super().__init__(*formula, arity=len(formula), **kwds)
 
@@ -1192,14 +1230,13 @@ class Bidirectional(_BinaryNeuron):
     ```
 
     """
+
     def __init__(self, *formula, **kwds):
         lhs, rhs = formula
         self.Imp1, self.Imp2 = Implies(lhs, rhs), Implies(rhs, lhs)
         super().__init__(self.Imp1, self.Imp2, **kwds)
-        self.func = self.neuron.function(
-            'And', direction=Direction.UPWARD)
-        self.func_inv = self.neuron.function(
-            'And', direction=Direction.DOWNWARD)
+        self.func = self.neuron.function("And", direction=Direction.UPWARD)
+        self.func_inv = self.neuron.function("And", direction=Direction.DOWNWARD)
 
     def upward(self, *args, **kwds) -> torch.Tensor:
         self.Imp1.upward(*args, **kwds)
@@ -1214,13 +1251,12 @@ class Bidirectional(_BinaryNeuron):
 
 class _UnaryOperator(_ConnectiveFormula):
     r"""Restrict operators to 1 input"""
-    def __init__(self,
-                 *formula: _Formula,
-                 **kwds):
+
+    def __init__(self, *formula: _Formula, **kwds):
         if len(formula) != 1:
             raise Exception(
-                'Unary operator expect 1 formula as input, received '
-                f'{len(formula)}')
+                "Unary operator expect 1 formula as input, received " f"{len(formula)}"
+            )
         super().__init__(*formula, **kwds)
 
 
@@ -1253,12 +1289,14 @@ class Not(_UnaryOperator):
     ```
 
     """
+
     def __init__(self, operand, **kwds):
         self.operand = operand[0] if isinstance(operand, Tuple) else operand
-        kwds.setdefault('name', 'Not_' + self.operand.name)
+        kwds.setdefault("name", "Not_" + self.operand.name)
         super().__init__(operand, arity=1, **kwds)
         self.neuron = _NodeActivation()(
-            self.propositional, self.world, **kwds.get('neuron', {}))
+            self.propositional, self.world, **kwds.get("neuron", {})
+        )
 
     def upward(self, **kwds) -> torch.Tensor:
         if self.propositional:
@@ -1269,7 +1307,8 @@ class Not(_UnaryOperator):
                 if g not in self.grounding_table:
                     self._add_groundings(g)
         return self.neuron.aggregate_bounds(
-            None, _utils.negate_bounds(self.operand.get_facts(*groundings)))
+            None, _utils.negate_bounds(self.operand.get_facts(*groundings))
+        )
 
     def downward(self) -> torch.Tensor:
         if self.propositional:
@@ -1280,7 +1319,8 @@ class Not(_UnaryOperator):
                 if g not in self.operand.groundings:
                     self.operand._add_groundings(g)
         return self.operand.neuron.aggregate_bounds(
-            None, _utils.negate_bounds(self.get_facts(*groundings)))
+            None, _utils.negate_bounds(self.get_facts(*groundings))
+        )
 
 
 class _Quantifier(_Formula):
@@ -1301,14 +1341,16 @@ class _Quantifier(_Formula):
             returns the slot index of each unique variable
 
     """
+
     def __init__(self, *args, **kwds):
         super().__init__(args[-1], arity=1, propositional=True, **kwds)
-        self.fully_grounded = kwds.get('fully_grounded', False)
+        self.fully_grounded = kwds.get("fully_grounded", False)
 
         # dimensions to quantify over
         self._update_variables(args[:-1])
         self.unique_var_slots = tuple(
-            self.var_remap[0].index(v) for v in self.unique_vars)
+            self.var_remap[0].index(v) for v in self.unique_vars
+        )
 
         self._grounding_set = set()
         self._set_activation()
@@ -1325,8 +1367,12 @@ class _Quantifier(_Formula):
         result = self.neuron.aggregate_bounds(
             None,
             self.func(input_bounds.permute([1, 0])),
-            bound=(('upper' if isinstance(self, ForAll) else 'lower')
-                   if not self.fully_grounded else None))
+            bound=(
+                ("upper" if isinstance(self, ForAll) else "lower")
+                if not self.fully_grounded
+                else None
+            ),
+        )
         return result
 
     def _set_activation(self) -> None:
@@ -1344,16 +1390,18 @@ class _Quantifier(_Formula):
             propagate via inference.
 
         """
-        operator = 'And' if isinstance(self, ForAll) else (
-            'Or' if isinstance(self, Exists) else None)
+        operator = (
+            "And"
+            if isinstance(self, ForAll)
+            else ("Or" if isinstance(self, Exists) else None)
+        )
         self.neuron = _NeuralActivation()(
-            self.propositional, len(self._grounding_set), self.world,
-            neuron={
-                'weights_learning': False,
-                'bias_learning': False}
-            )
-        self.func = self.neuron.function(
-            operator, direction=Direction.UPWARD)
+            self.propositional,
+            len(self._grounding_set),
+            self.world,
+            neuron={"weights_learning": False, "bias_learning": False},
+        )
+        self.func = self.neuron.function(operator, direction=Direction.UPWARD)
 
     @property
     def has_free_variables(self) -> bool:
@@ -1363,22 +1411,28 @@ class _Quantifier(_Formula):
     @property
     def true_groundings(self) -> Set[Union[str, Tuple[str, ...]]]:
         r"""Returns set of groundings that are True"""
-        return set(tuple(str(g.partial_grounding[slot])
-                         for g in self._grounding_set
-                         if self.operands[0].state(g) is Fact.TRUE
-                         for slot in self.unique_var_slots))
+        return set(
+            tuple(
+                str(g.partial_grounding[slot])
+                for g in self._grounding_set
+                if self.operands[0].state(g) is Fact.TRUE
+                for slot in self.unique_var_slots
+            )
+        )
 
-    def _upward_bounds(self, operand: _Formula
-                       ) -> Union[torch.Tensor, None]:
+    def _upward_bounds(self, operand: _Formula) -> Union[torch.Tensor, None]:
         r"""set Quantifer grounding table and return operand tensor"""
         operand_grounding_set = set(operand.grounding_table)
         if len(operand_grounding_set) == 0:
             return
 
-        self._grounding_set = set([
-            grounding
-            for grounding in operand_grounding_set
-            if _gm.is_grounding_in_bindings(self, 0, grounding)])
+        self._grounding_set = set(
+            [
+                grounding
+                for grounding in operand_grounding_set
+                if _gm.is_grounding_in_bindings(self, 0, grounding)
+            ]
+        )
         result = operand.get_facts(*self._grounding_set)
         return result
 
@@ -1406,9 +1460,13 @@ class ForAll(_Quantifier):
         Currently not implemented
 
     """
+
     def __init__(self, *args, **kwds):
-        kwds.setdefault('name', 'All_' + (args[-1][0].name if isinstance(
-            args[-1], Tuple) else args[-1].name))
+        kwds.setdefault(
+            "name",
+            "All_"
+            + (args[-1][0].name if isinstance(args[-1], Tuple) else args[-1].name),
+        )
         super().__init__(*args, **kwds)
 
     def downward(self) -> torch.Tensor:
@@ -1417,8 +1475,8 @@ class ForAll(_Quantifier):
         current_bounds = self.get_facts()
         groundings = operand.grounding_table.keys()
         result = operand.neuron.aggregate_bounds(
-            [operand.grounding_table.get(g) for g in groundings],
-            current_bounds)
+            [operand.grounding_table.get(g) for g in groundings], current_bounds
+        )
         return result
 
 
@@ -1437,30 +1495,38 @@ class Exists(_Quantifier):
         Currently not implemented
 
     """
+
     def __init__(self, *args, **kwds):
-        kwds.setdefault('name', 'Some_' + (args[-1][0].name if isinstance(
-            args[-1], Tuple) else args[-1].name))
+        kwds.setdefault(
+            "name",
+            "Some_"
+            + (args[-1][0].name if isinstance(args[-1], Tuple) else args[-1].name),
+        )
         super().__init__(*args, **kwds)
 
 
 class _NodeActivation:
     def __call__(self, propositional: bool, world: World, **kwds):
-        return getattr(import_module(
-            'lnn.neural.activations.node'), '_NodeActivation')(
-            propositional, world, **kwds)
+        return getattr(import_module("lnn.neural.activations.node"), "_NodeActivation")(
+            propositional, world, **kwds
+        )
 
 
 class _NeuralActivation:
     r"""Switch class, to choose a method from the correct activation class"""
+
     def __init__(self, type=None):
-        self.neuron_type = type if type else (
-            NeuralActivationClass.LukasiewiczTransparent)
+        self.neuron_type = (
+            type if type else (NeuralActivationClass.LukasiewiczTransparent)
+        )
         self.module = import_module(
-            f"lnn.neural.methods.{self.neuron_type.name.lower()}")
+            f"lnn.neural.methods.{self.neuron_type.name.lower()}"
+        )
 
     def __call__(self, propositional: bool, arity: int, world: World, **kwds):
         return getattr(self.module, self.neuron_type.name)(
-            propositional, arity, world, **kwds)
+            propositional, arity, world, **kwds
+        )
 
 
 class NeuralActivationClass(AutoName):

--- a/lnn/utils.py
+++ b/lnn/utils.py
@@ -81,12 +81,12 @@ def plot_graph(self, **kwds) -> None:
     labels = {node: f"{node.__class__.__name__}\n{node}" for node in self.graph}
 
     options = {
-        'with_labels': True,
-        'arrows': True,
-        'edge_color': '#d0e2ff',
-        'node_size': 1,
-        'font_size': 9,
-        'labels': labels
+        "with_labels": True,
+        "arrows": True,
+        "edge_color": "#d0e2ff",
+        "node_size": 1,
+        "font_size": 9,
+        "labels": labels,
     }
 
     options.update(kwds)

--- a/lnn/utils.py
+++ b/lnn/utils.py
@@ -63,6 +63,7 @@ def predicate_truth_table(*args: str, arity: int, model, states=None):
     if states is None:
         states = [FALSE, TRUE]
     from lnn import Predicate  # noqa: F401
+
     n = len(args)
     TT = np.array(truth_table(n, states))
     _range = list(range(len(TT)))
@@ -70,7 +71,7 @@ def predicate_truth_table(*args: str, arity: int, model, states=None):
         model[arg] = Predicate(arity=arity)
         random.shuffle(_range)
         for i in _range:
-            grounding = f'{i}' if arity == 1 else (f'{i}',)*arity
+            grounding = f"{i}" if arity == 1 else (f"{i}",) * arity
             truth = TT[i, idx].item()
             model[arg].add_facts({grounding: truth})
     return model
@@ -89,7 +90,7 @@ def plot_graph(self, **kwds) -> None:
     }
 
     options.update(kwds)
-    pos = nx.drawing.nx_agraph.graphviz_layout(self.graph, prog='dot')
+    pos = nx.drawing.nx_agraph.graphviz_layout(self.graph, prog="dot")
     nx.draw(self.graph, pos, **options)
 
     plt.show()
@@ -98,35 +99,35 @@ def plot_graph(self, **kwds) -> None:
 def plot_loss(total_loss, losses) -> None:
     loss, cummulative_loss = total_loss
     fig, axs = plt.subplots(1, 2)
-    fig.suptitle('Model Loss')
+    fig.suptitle("Model Loss")
     axs[0].plot(np.array(loss))
     for ax in axs.flat:
-        ax.set(xlabel='Epochs', ylabel='Loss')
-    axs[0].legend(['Total Loss'])
+        ax.set(xlabel="Epochs", ylabel="Loss")
+    axs[0].legend(["Total Loss"])
     axs[1].plot(np.array(cummulative_loss))
     axs[1].legend([str.capitalize(i) for i in losses])
     plt.show()
 
 
-Model = TypeVar('Model')
+Model = TypeVar("Model")
 
 
 def plot_params(self: Model) -> None:
     legend = []
     for node in self.nodes:
-        if hasattr(self[node], 'parameter_history'):
+        if hasattr(self[node], "parameter_history"):
             for param, data in self[node].parameter_history.items():
                 if isinstance(data[0], list):
                     operands = list(self[node].operands)
-                    legend_idxs = [
-                        f'_{operands[i]}' for i in list(range(len(data[0])))]
+                    legend_idxs = [f"_{operands[i]}" for i in list(range(len(data[0])))]
                 else:
-                    legend_idxs = ['']
-                [legend.append(
-                    f'{node} {_utils.param_symbols[param]}{i}')
-                    for i in legend_idxs]
+                    legend_idxs = [""]
+                [
+                    legend.append(f"{node} {_utils.param_symbols[param]}{i}")
+                    for i in legend_idxs
+                ]
                 plt.plot(data)
-    plt.xlabel('Epochs')
+    plt.xlabel("Epochs")
     plt.legend(legend)
-    plt.title(f'{self.name} Parameters')
+    plt.title(f"{self.name} Parameters")
     plt.show()

--- a/setup.py
+++ b/setup.py
@@ -6,28 +6,27 @@
 
 import setuptools
 
-with open('README.md', 'r') as f:
+with open("README.md", "r") as f:
     long_description = f.read()
 
-with open('requirements.txt', 'r') as f:
-    install_requires = f.read().replace('==', '>=')
+with open("requirements.txt", "r") as f:
+    install_requires = f.read().replace("==", ">=")
 
 setuptools.setup(
-    name='lnn',
-    version='1.0',
-    author='IBM Research',
-    description='A `Neuro = Symbolic` framework for weighted '
-                'real-valued logic',
+    name="lnn",
+    version="1.0",
+    author="IBM Research",
+    description="A `Neuro = Symbolic` framework for weighted " "real-valued logic",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/IBM/LNN',
+    long_description_content_type="text/markdown",
+    url="https://github.com/IBM/LNN",
     packages=setuptools.find_packages(),
     install_requires=install_requires,
     classifiers=[
-        'Programming Language :: Python :: 3',
-        'Operating System :: OS Independent',
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
     ],
-    python_requires='>=3.9',
+    python_requires=">=3.9",
 )
 
 print(setuptools)

--- a/tests/learning/fol/test_bool_and_1.py
+++ b/tests/learning/fol/test_bool_and_1.py
@@ -4,44 +4,50 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, And, Variable, plot_loss, plot_params, World,
-                 TRUE, FALSE, UNKNOWN, UPWARD)
+from lnn import (
+    Model,
+    And,
+    Variable,
+    plot_loss,
+    plot_params,
+    World,
+    TRUE,
+    FALSE,
+    UNKNOWN,
+    UPWARD,
+)
 
 
 def test():
     model = Model()
 
-    p1, p2 = model.add_predicates(1, 'P1', 'P2')
+    p1, p2 = model.add_predicates(1, "P1", "P2")
 
-    model.add_facts({
-        p1.name: {
-            '0': TRUE,
-            '1': TRUE,
-            '2': TRUE,
-            '3': TRUE
-        },
-        p2.name: {
-            '0': TRUE,
-            '1': UNKNOWN,
-            '2': FALSE,
-            '3': FALSE,
+    model.add_facts(
+        {
+            p1.name: {"0": TRUE, "1": TRUE, "2": TRUE, "3": TRUE},
+            p2.name: {
+                "0": TRUE,
+                "1": UNKNOWN,
+                "2": FALSE,
+                "3": FALSE,
+            },
         }
-    })
+    )
 
-    x = Variable('x')
-    model['AB'] = And(p1(x), p2(x), world=World.AXIOM)
-    parameter_history = {'weights': True, 'bias': True}
-    losses = ['contradiction', 'logical']
+    x = Variable("x")
+    model["AB"] = And(p1(x), p2(x), world=World.AXIOM)
+    parameter_history = {"weights": True, "bias": True}
+    losses = ["contradiction", "logical"]
     total_loss, _ = model.train(
-        direction=UPWARD,
-        losses=losses,
-        parameter_history=parameter_history
+        direction=UPWARD, losses=losses, parameter_history=parameter_history
     )
     model.print(params=True)
     predictions = model[p1.name].state().values()
     assert all([fact is TRUE for fact in predictions]), (
-        'expected AB Facts to all be TRUE, received bounds '
-        f'{[p.name for p in predictions]}')
+        "expected AB Facts to all be TRUE, received bounds "
+        f"{[p.name for p in predictions]}"
+    )
 
     return model, total_loss, losses
 

--- a/tests/learning/fol/test_bool_and_supervised_1.py
+++ b/tests/learning/fol/test_bool_and_supervised_1.py
@@ -4,50 +4,57 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, And, Variable, plot_loss, plot_params,
-                 TRUE, FALSE, UNKNOWN, UPWARD)
+from lnn import (
+    Model,
+    And,
+    Variable,
+    plot_loss,
+    plot_params,
+    TRUE,
+    FALSE,
+    UNKNOWN,
+    UPWARD,
+)
 
 
 def test():
     model = Model()
-    p1, p2 = model.add_predicates(1, 'P1', 'P2')
-    model.add_facts({
-        p1.name: {
-            '0': TRUE,
-            '1': TRUE,
-            '2': TRUE,
-            '3': TRUE
-        },
-        p2.name: {
-            '0': TRUE,
-            '1': UNKNOWN,
-            '2': FALSE,
-            '3': FALSE,
+    p1, p2 = model.add_predicates(1, "P1", "P2")
+    model.add_facts(
+        {
+            p1.name: {"0": TRUE, "1": TRUE, "2": TRUE, "3": TRUE},
+            p2.name: {
+                "0": TRUE,
+                "1": UNKNOWN,
+                "2": FALSE,
+                "3": FALSE,
+            },
         }
-    })
+    )
 
-    x = Variable('x')
-    model['AB'] = And(p1(x), p2(x))
-    model.add_labels({
-        'AB': {
-            '0': TRUE,
-            '1': UNKNOWN,
-            '2': TRUE,
-            '3': FALSE,
+    x = Variable("x")
+    model["AB"] = And(p1(x), p2(x))
+    model.add_labels(
+        {
+            "AB": {
+                "0": TRUE,
+                "1": UNKNOWN,
+                "2": TRUE,
+                "3": FALSE,
+            }
         }
-    })
-    parameter_history = {'weights': True, 'bias': True}
-    losses = ['logical', 'supervised']
+    )
+    parameter_history = {"weights": True, "bias": True}
+    losses = ["logical", "supervised"]
     total_loss, _ = model.train(
-        direction=UPWARD,
-        losses=losses,
-        parameter_history=parameter_history
+        direction=UPWARD, losses=losses, parameter_history=parameter_history
     )
     model.print(params=True)
     predictions = model[p1.name].state().values()
     assert all([fact is TRUE for fact in predictions]), (
-        'expected AB Facts to all be TRUE, received bounds '
-        f'{[p.name for p in predictions]}')
+        "expected AB Facts to all be TRUE, received bounds "
+        f"{[p.name for p in predictions]}"
+    )
 
     return model, total_loss, losses
 

--- a/tests/learning/fol/test_supervised_atagent_1.py
+++ b/tests/learning/fol/test_supervised_atagent_1.py
@@ -6,19 +6,23 @@
 
 import itertools
 
-from lnn import (Model, World, And, Bidirectional, ForAll, Variable,
-                 TRUE, UPWARD)
+from lnn import Model, World, And, Bidirectional, ForAll, Variable, TRUE, UPWARD
 
 
 def test():
     # background data (features)
-    B = {'at-agent': [('cabinet',), ('wardrobe',), ('hanger',),
-                      ('ladderback chair',)],
-         'in': [('cabinet', 'shoe'), ('wardrobe', 'shirt'),
-                ('hanger', 'coat'), ('ladderback chair', 'tuna'), ]}
+    B = {
+        "at-agent": [("cabinet",), ("wardrobe",), ("hanger",), ("ladderback chair",)],
+        "in": [
+            ("cabinet", "shoe"),
+            ("wardrobe", "shirt"),
+            ("hanger", "coat"),
+            ("ladderback chair", "tuna"),
+        ],
+    }
 
     # positive (target) labels
-    P = {'take': [('shoe',), ('shirt',), ('coat',), ('tuna',)]}
+    P = {"take": [("shoe",), ("shirt",), ("coat",), ("tuna",)]}
 
     # Predicates:
     # ['at-agent(x)', 'at-agent(z)', 'in(x,z)', 'in(z,x)']
@@ -30,52 +34,55 @@ def test():
     # take(x):- at-agent(z) ∧ in(z, x)
 
     model = Model()
-    at_agent = model.add_predicates(1, 'at-agent', world=World.FALSE)
-    in_ = model.add_predicates(2, 'in', world=World.FALSE)
-    take = model.add_predicates(1, 'take', world=World.FALSE)
+    at_agent = model.add_predicates(1, "at-agent", world=World.FALSE)
+    in_ = model.add_predicates(2, "in", world=World.FALSE)
+    take = model.add_predicates(1, "take", world=World.FALSE)
 
-    model.add_facts({
-        'at-agent': {c: TRUE for c in B['at-agent']},
-        'in': {pair: TRUE for pair in B['in']},
-        'take': {c: TRUE for c in P['take']}})
+    model.add_facts(
+        {
+            "at-agent": {c: TRUE for c in B["at-agent"]},
+            "in": {pair: TRUE for pair in B["in"]},
+            "take": {c: TRUE for c in P["take"]},
+        }
+    )
 
-    x = Variable('x')
-    z = Variable('z')
+    x = Variable("x")
+    z = Variable("z")
 
     variables = [x, z]
     singles = [(x,), (z,)]
     pairs = itertools.permutations(variables, 2)  # e.g. [(x, y), ...]
     pairs = list(pairs)
 
-    neuron = {
-        'bias_learning': False,
-        'weights_learning': False}
+    neuron = {"bias_learning": False, "weights_learning": False}
 
     subrules = []
     for single in singles:
         for pair in pairs:
             k = str(len(subrules))
-            model[k] = ForAll(Bidirectional(And(at_agent(*single),
-                                                in_(*pair), neuron=neuron),
-                                            take(x), neuron=neuron),
-                              fully_grounded=True)
+            model[k] = ForAll(
+                Bidirectional(
+                    And(at_agent(*single), in_(*pair), neuron=neuron),
+                    take(x),
+                    neuron=neuron,
+                ),
+                fully_grounded=True,
+            )
             subrules.append(model[k])
 
-    rule = model['rule'] = And(*subrules, world=World.AXIOM,
-                               neuron={'bias_learning': False})
+    rule = model["rule"] = And(
+        *subrules, world=World.AXIOM, neuron={"bias_learning": False}
+    )
 
-    parameter_history = {'weights': True, 'bias': True}
-    losses = {'contradiction': 1}
+    parameter_history = {"weights": True, "bias": True}
+    losses = {"contradiction": 1}
 
     total_loss, _ = model.train(
-        direction=UPWARD,
-        losses=losses,
-        parameter_history=parameter_history
+        direction=UPWARD, losses=losses, parameter_history=parameter_history
     )
 
     chosen_idx = []
-    weighted_idx = (rule.neuron.weights == 1).nonzero(
-        as_tuple=True)[0]
+    weighted_idx = (rule.neuron.weights == 1).nonzero(as_tuple=True)[0]
     for idx in weighted_idx:
         subrule_forall = rule.operands[idx]
         if subrule_forall.neuron.bounds_table[0][0] == 1:
@@ -86,12 +93,12 @@ def test():
             chosen_idx.append(subrule_and_vars)
 
     num_chosen = len(chosen_idx)
-    assert num_chosen == 1, 'expected 1 got ' + str(num_chosen)
-    assert chosen_idx[0] == ['z', 'z, x'], (
-            'expected ' + str(['z', 'z, x']) +
-            ' got ' + str(chosen_idx[0]))
+    assert num_chosen == 1, "expected 1 got " + str(num_chosen)
+    assert chosen_idx[0] == ["z", "z, x"], (
+        "expected " + str(["z", "z, x"]) + " got " + str(chosen_idx[0])
+    )
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/learning/fol/test_supervised_atlocation_1.py
+++ b/tests/learning/fol/test_supervised_atlocation_1.py
@@ -6,22 +6,31 @@
 
 import itertools
 
-from lnn import (Model, World, And, Bidirectional, ForAll, Variable,
-                 TRUE, UPWARD)
+from lnn import Model, World, And, Bidirectional, ForAll, Variable, TRUE, UPWARD
 
 
 def test():
     # background data (features)
-    B = {'atlocation': [('hat', 'rack'), ('moccasins', 'cabinet'),
-                        ('tissue', 'basket')],
-         'related_to': [('shoe cabinet', 'cabinet'), ('hat rack', 'rack'),
-                        ('top hat', 'hat'), ('blue moccasins', 'moccasins'),
-                        ('used tissue', 'tissue'),
-                        ('wastepaper basket', 'basket')]}
+    B = {
+        "atlocation": [("hat", "rack"), ("moccasins", "cabinet"), ("tissue", "basket")],
+        "related_to": [
+            ("shoe cabinet", "cabinet"),
+            ("hat rack", "rack"),
+            ("top hat", "hat"),
+            ("blue moccasins", "moccasins"),
+            ("used tissue", "tissue"),
+            ("wastepaper basket", "basket"),
+        ],
+    }
 
     # positive (target) labels
-    P = {'put': [('top hat', 'hat rack'), ('blue moccasins', 'shoe cabinet'),
-                 ('used tissue', 'wastepaper basket')]}
+    P = {
+        "put": [
+            ("top hat", "hat rack"),
+            ("blue moccasins", "shoe cabinet"),
+            ("used tissue", "wastepaper basket"),
+        ]
+    }
 
     # Predicates:
     # ['atlocation( x,y)', 'atlocation( x,u)', 'atlocation( x,v)',
@@ -36,28 +45,33 @@ def test():
     # Learned rule:
     # put(x,y):- related_to(x,u) ∧ atlocation(u,v) ∧ related_to(y,v)
 
-    valid_rules = [['x, u', 'u, v', 'y, v'],
-                   ['x, v', 'v, u', 'y, u'],
-                   ['y, u', 'v, u', 'x, v'],
-                   ['y, v', 'u, v', 'x, u']]
+    valid_rules = [
+        ["x, u", "u, v", "y, v"],
+        ["x, v", "v, u", "y, u"],
+        ["y, u", "v, u", "x, v"],
+        ["y, v", "u, v", "x, u"],
+    ]
 
     # Subrule template:
     # put(x,y):- related_to(*,*) ∧ atlocation(*,*) ∧ related_to(*,*) [x,y,u,v]
 
     model = Model()
-    atlocation = model.add_predicates(2, 'atlocation', world=World.FALSE)
-    related_to = model.add_predicates(2, 'related_to', world=World.FALSE)
-    put = model.add_predicates(2, 'put', world=World.FALSE)
+    atlocation = model.add_predicates(2, "atlocation", world=World.FALSE)
+    related_to = model.add_predicates(2, "related_to", world=World.FALSE)
+    put = model.add_predicates(2, "put", world=World.FALSE)
 
-    model.add_facts({
-        'atlocation': {pair: TRUE for pair in B['atlocation']},
-        'related_to': {pair: TRUE for pair in B['related_to']},
-        'put': {pair: TRUE for pair in P['put']}})
+    model.add_facts(
+        {
+            "atlocation": {pair: TRUE for pair in B["atlocation"]},
+            "related_to": {pair: TRUE for pair in B["related_to"]},
+            "put": {pair: TRUE for pair in P["put"]},
+        }
+    )
 
-    x = Variable('x')
-    y = Variable('y')
-    u = Variable('u')
-    v = Variable('v')
+    x = Variable("x")
+    y = Variable("y")
+    u = Variable("u")
+    v = Variable("v")
 
     variables = [x, y, u, v]
     pairs = itertools.permutations(variables, 2)  # e.g. [(x, y), ...]
@@ -68,45 +82,47 @@ def test():
     rule_vars = itertools.permutations(pairs, 3)
     rule_vars = list(rule_vars)
 
-    '''
+    """
     rule_vars = [((x, u), (u, v), (y, v)), ((x, y), (x, u), (x, v)),
                  ((x, y), (x, u), (y, x)), ((x, v), (v, u), (y, u)),
                  ((u, y), (u, v), (v, u)), ((y, v), (u, y), (v, u)),
                  ((x, u), (u, x), (v, u)), ((x, u), (x, v), (y, u)),
                  ((x, u), (u, v), (v, x)), ((x, y), (y, x), (v, x))]
-    '''
-    neuron = {
-        'bias_learning': False,
-        'weights_learning': False}
+    """
+    neuron = {"bias_learning": False, "weights_learning": False}
 
     subrules = []
     for i, preds_vars in enumerate(rule_vars):
         vars1, vars2, vars3 = preds_vars
-        model[str(i)] = ForAll(Bidirectional(And(related_to(*vars1),
-                                                 atlocation(*vars2),
-                                                 related_to(*vars3),
-                                                 neuron=neuron),
-                                             put(x, y),
-                                             neuron=neuron),
-                               fully_grounded=True)
+        model[str(i)] = ForAll(
+            Bidirectional(
+                And(
+                    related_to(*vars1),
+                    atlocation(*vars2),
+                    related_to(*vars3),
+                    neuron=neuron,
+                ),
+                put(x, y),
+                neuron=neuron,
+            ),
+            fully_grounded=True,
+        )
         subrules.append(model[str(i)])
 
-    rule = model['rule'] = And(*subrules, world=World.AXIOM,
-                               neuron={'bias_learning': False})
+    rule = model["rule"] = And(
+        *subrules, world=World.AXIOM, neuron={"bias_learning": False}
+    )
 
-    parameter_history = {'weights': True, 'bias': True}
-    losses = {'contradiction': 1}
+    parameter_history = {"weights": True, "bias": True}
+    losses = {"contradiction": 1}
 
     total_loss, _ = model.train(
-        direction=UPWARD,
-        losses=losses,
-        parameter_history=parameter_history
+        direction=UPWARD, losses=losses, parameter_history=parameter_history
     )
 
     chosen_idx = []
     rule_idx = []
-    weighted_idx = (rule.neuron.weights == 1).nonzero(
-        as_tuple=True)[0]
+    weighted_idx = (rule.neuron.weights == 1).nonzero(as_tuple=True)[0]
     for idx in weighted_idx:
         subrule_forall = rule.operands[idx]
         if subrule_forall.neuron.bounds_table[0][0] == 1:
@@ -118,12 +134,11 @@ def test():
             rule_idx.append(idx)
 
     num_chosen = len(chosen_idx)
-    assert num_chosen == 4, 'expected 4 got ' + str(num_chosen)
+    assert num_chosen == 4, "expected 4 got " + str(num_chosen)
 
-    assert all([r in valid_rules for r in chosen_idx]), ('some rule(s)' +
-                                                         'are not found')
+    assert all([r in valid_rules for r in chosen_idx]), "some rule(s)" + "are not found"
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/learning/fol/test_supervised_atlocation_2.py
+++ b/tests/learning/fol/test_supervised_atlocation_2.py
@@ -6,8 +6,18 @@
 
 import itertools
 
-from lnn import (Model, World, And, Bidirectional, ForAll, Variable,
-                 TRUE, UPWARD, UNKNOWN, Implies)
+from lnn import (
+    Model,
+    World,
+    And,
+    Bidirectional,
+    ForAll,
+    Variable,
+    TRUE,
+    UPWARD,
+    UNKNOWN,
+    Implies,
+)
 
 
 def prune_rules(B, P, variables, rule_vars):
@@ -22,62 +32,96 @@ def prune_rules(B, P, variables, rule_vars):
     :return: Sum of facts correctly predicted as True.
     """
 
-    neuron = {
-        'bias_learning': False,
-        'weights_learning': False}
+    neuron = {"bias_learning": False, "weights_learning": False}
     model = Model()
-    atlocation = model.add_predicates(2, 'atlocation', world=World.FALSE)
-    related_to = model.add_predicates(2, 'related_to', world=World.FALSE)
-    put = model.add_predicates(2, 'put', world=World.FALSE)
+    atlocation = model.add_predicates(2, "atlocation", world=World.FALSE)
+    related_to = model.add_predicates(2, "related_to", world=World.FALSE)
+    put = model.add_predicates(2, "put", world=World.FALSE)
 
-    model.add_facts({
-        'atlocation': {pair: TRUE for pair in B['atlocation']},
-        'related_to': {pair: TRUE for pair in B['related_to']},
-        'put': {pair: UNKNOWN for pair in P['put']}})
+    model.add_facts(
+        {
+            "atlocation": {pair: TRUE for pair in B["atlocation"]},
+            "related_to": {pair: TRUE for pair in B["related_to"]},
+            "put": {pair: UNKNOWN for pair in P["put"]},
+        }
+    )
 
     # Set ground truth for target predicate
     GT = {}
-    for grounding in P['put']:
+    for grounding in P["put"]:
         GT[grounding] = TRUE
 
     x, y, u, v = variables
     vars1, vars2, vars3 = rule_vars
-    model['test_rule'] = ForAll(Implies(And(related_to(*vars1),
-                                            atlocation(*vars2),
-                                            related_to(*vars3),
-                                            neuron=neuron),
-                                        put(x, y),
-                                        neuron=neuron),
-                                world=World.AXIOM)
+    model["test_rule"] = ForAll(
+        Implies(
+            And(
+                related_to(*vars1),
+                atlocation(*vars2),
+                related_to(*vars3),
+                neuron=neuron,
+            ),
+            put(x, y),
+            neuron=neuron,
+        ),
+        world=World.AXIOM,
+    )
 
     model.infer()
 
-    return sum([model['put'].state(groundings=g) is GT[g] for g in GT])
+    return sum([model["put"].state(groundings=g) is GT[g] for g in GT])
 
 
 def test():
     # background data (features)
-    B = {'atlocation': [('towel', 'towel rail'), ('cap', 'hat rack'),
-                        ('flour', 'shelf'), ('handsoap', 'sink'),
-                        ('sugar', 'shelf'), ('shoes', 'cabinet'),
-                        ('peanut oil', 'shelf'), ('bathrobe', 'hook'),
-                        ('white cap', 'hat rack')],
-         'related_to': [('white cap', 'white cap'), ('hat rack', 'hat rack'),
-                        ('shelf', 'shelf'), ('handsoap', 'handsoap'),
-                        ('bathrobe', 'bathrobe'), ('flour', 'flour'),
-                        ('towel', 'towel'), ('towel rail', 'towel rail'),
-                        ('peanut oil', 'peanut oil'), ('wall hook', 'hook'),
-                        ('sugar', 'sugar'), ('sink', 'sink'),
-                        ('climbing shoes', 'shoes'), ('brown cap', 'cap'),
-                        ('white cap', 'cap'), ('shoe cabinet', 'cabinet')]}
+    B = {
+        "atlocation": [
+            ("towel", "towel rail"),
+            ("cap", "hat rack"),
+            ("flour", "shelf"),
+            ("handsoap", "sink"),
+            ("sugar", "shelf"),
+            ("shoes", "cabinet"),
+            ("peanut oil", "shelf"),
+            ("bathrobe", "hook"),
+            ("white cap", "hat rack"),
+        ],
+        "related_to": [
+            ("white cap", "white cap"),
+            ("hat rack", "hat rack"),
+            ("shelf", "shelf"),
+            ("handsoap", "handsoap"),
+            ("bathrobe", "bathrobe"),
+            ("flour", "flour"),
+            ("towel", "towel"),
+            ("towel rail", "towel rail"),
+            ("peanut oil", "peanut oil"),
+            ("wall hook", "hook"),
+            ("sugar", "sugar"),
+            ("sink", "sink"),
+            ("climbing shoes", "shoes"),
+            ("brown cap", "cap"),
+            ("white cap", "cap"),
+            ("shoe cabinet", "cabinet"),
+        ],
+    }
 
     # (noisy) positive (target) labels
-    P = {'put': [('towel', 'towel rail'), ('flour', 'shelf'),
-                 ('handsoap', 'sink'), ('sugar', 'shelf'),
-                 ('peanut oil', 'shelf'), ('bathrobe', 'wall hook'),
-                 ('brown cap', 'hat rack'), ('white cap', 'hat rack'),
-                 ('flour', 'folding chair'), ('sugar', 'folding chair'),
-                 ('peanut oil', 'folding chair')]}
+    P = {
+        "put": [
+            ("towel", "towel rail"),
+            ("flour", "shelf"),
+            ("handsoap", "sink"),
+            ("sugar", "shelf"),
+            ("peanut oil", "shelf"),
+            ("bathrobe", "wall hook"),
+            ("brown cap", "hat rack"),
+            ("white cap", "hat rack"),
+            ("flour", "folding chair"),
+            ("sugar", "folding chair"),
+            ("peanut oil", "folding chair"),
+        ]
+    }
 
     # Predicates:
     # ['atlocation( x,y)', 'atlocation( x,u)', 'atlocation( x,v)',
@@ -92,28 +136,33 @@ def test():
     # Learned rule:
     # put(x,y):- related_to(x,u) ∧ atlocation(u,v) ∧ related_to(y,v)
 
-    valid_rules = [['x, u', 'u, v', 'y, v'],
-                   ['x, v', 'v, u', 'y, u'],
-                   ['y, u', 'v, u', 'x, v'],
-                   ['y, v', 'u, v', 'x, u']]
+    valid_rules = [
+        ["x, u", "u, v", "y, v"],
+        ["x, v", "v, u", "y, u"],
+        ["y, u", "v, u", "x, v"],
+        ["y, v", "u, v", "x, u"],
+    ]
 
     # Subrule template:
     # put(x,y):- related_to(*,*) ∧ atlocation(*,*) ∧ related_to(*,*) [x,y,u,v]
 
     model = Model()
-    atlocation = model.add_predicates(2, 'atlocation', world=World.FALSE)
-    related_to = model.add_predicates(2, 'related_to', world=World.FALSE)
-    put = model.add_predicates(2, 'put', world=World.FALSE)
+    atlocation = model.add_predicates(2, "atlocation", world=World.FALSE)
+    related_to = model.add_predicates(2, "related_to", world=World.FALSE)
+    put = model.add_predicates(2, "put", world=World.FALSE)
 
-    model.add_facts({
-        'atlocation': {pair: TRUE for pair in B['atlocation']},
-        'related_to': {pair: TRUE for pair in B['related_to']},
-        'put': {pair: TRUE for pair in P['put']}})
+    model.add_facts(
+        {
+            "atlocation": {pair: TRUE for pair in B["atlocation"]},
+            "related_to": {pair: TRUE for pair in B["related_to"]},
+            "put": {pair: TRUE for pair in P["put"]},
+        }
+    )
 
-    x = Variable('x')
-    y = Variable('y')
-    u = Variable('u')
-    v = Variable('v')
+    x = Variable("x")
+    y = Variable("y")
+    u = Variable("u")
+    v = Variable("v")
 
     variables = [x, y, u, v]
     pairs = itertools.permutations(variables, 2)  # e.g. [(x, y), ...]
@@ -124,9 +173,7 @@ def test():
     rule_vars = itertools.permutations(pairs, 3)
     rule_vars = list(rule_vars)
 
-    neuron = {
-        'bias_learning': False,
-        'weights_learning': False}
+    neuron = {"bias_learning": False, "weights_learning": False}
 
     subrules = []
     valid_sub_rules = []
@@ -139,31 +186,35 @@ def test():
         # Filter rules who have head variables not appearing in body.
         if all([var in body_vars for var in head_vars]):
             valid_sub_rules.append(preds_vars)
-            model[str(i)] = ForAll(Bidirectional(And(related_to(*vars1),
-                                                     atlocation(*vars2),
-                                                     related_to(*vars3),
-                                                     neuron=neuron),
-                                                 put(x, y),
-                                                 neuron=neuron),
-                                   fully_grounded=True)
+            model[str(i)] = ForAll(
+                Bidirectional(
+                    And(
+                        related_to(*vars1),
+                        atlocation(*vars2),
+                        related_to(*vars3),
+                        neuron=neuron,
+                    ),
+                    put(x, y),
+                    neuron=neuron,
+                ),
+                fully_grounded=True,
+            )
             subrules.append(model[str(i)])
 
-    rule = model['rule'] = And(*subrules, world=World.AXIOM,
-                               neuron={'bias_learning': False})
+    rule = model["rule"] = And(
+        *subrules, world=World.AXIOM, neuron={"bias_learning": False}
+    )
 
-    parameter_history = {'weights': True, 'bias': True}
-    losses = {'contradiction': 1}
+    parameter_history = {"weights": True, "bias": True}
+    losses = {"contradiction": 1}
 
     total_loss, _ = model.train(
-        direction=UPWARD,
-        losses=losses,
-        parameter_history=parameter_history
+        direction=UPWARD, losses=losses, parameter_history=parameter_history
     )
 
     chosen_idx = []
     best_value = 0
-    weighted_idx = (rule.neuron.weights == 1).nonzero(
-        as_tuple=True)[0]
+    weighted_idx = (rule.neuron.weights == 1).nonzero(as_tuple=True)[0]
     for idx in weighted_idx:
         subrule_forall = rule.operands[idx]
         if subrule_forall.neuron.bounds_table[0][0] == 1:
@@ -177,9 +228,9 @@ def test():
                 subrule_and_vars = subrule_and.binding_str
                 chosen_idx = subrule_and_vars
 
-    assert chosen_idx in valid_rules, 'Incorrect rule.'
+    assert chosen_idx in valid_rules, "Incorrect rule."
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/learning/fol/test_supervised_family_tree.py
+++ b/tests/learning/fol/test_supervised_family_tree.py
@@ -7,8 +7,7 @@
 import itertools
 import random
 
-from lnn import (Model, World, And, Bidirectional, ForAll, Variable,
-                 TRUE, FALSE, UPWARD)
+from lnn import Model, World, And, Bidirectional, ForAll, Variable, TRUE, FALSE, UPWARD
 
 
 def test_1():
@@ -19,19 +18,41 @@ def test_1():
 
     # background data (features)
 
-    B = ['isFather', [('a', 'b'), ('b', 'c'), ('d', 'e'),
-                      ('f', 'g'), ('e', 'h'), ('g', 'a'),
-                      ('d', 'f'), ('a', 'j'), ('g', 'i')]]
+    B = [
+        "isFather",
+        [
+            ("a", "b"),
+            ("b", "c"),
+            ("d", "e"),
+            ("f", "g"),
+            ("e", "h"),
+            ("g", "a"),
+            ("d", "f"),
+            ("a", "j"),
+            ("g", "i"),
+        ],
+    ]
 
     # positive (target) labels for isGrandFather(x,y)
 
-    P1 = ['isGrandFather', [('a', 'c'), ('g', 'b'), ('f', 'a'),
-                            ('d', 'g'), ('d', 'h'), ('g', 'j'),
-                            ('f', 'i')]]
+    P1 = [
+        "isGrandFather",
+        [
+            ("a", "c"),
+            ("g", "b"),
+            ("f", "a"),
+            ("d", "g"),
+            ("d", "h"),
+            ("g", "j"),
+            ("f", "i"),
+        ],
+    ]
 
     # positive (target) labels for isSibling(x,y)
-    P2 = ['isSibling', [('j', 'b'), ('b', 'j'), ('a', 'i'),
-                        ('i', 'a'), ('f', 'e'), ('e', 'f')]]
+    P2 = [
+        "isSibling",
+        [("j", "b"), ("b", "j"), ("a", "i"), ("i", "a"), ("f", "e"), ("e", "f")],
+    ]
 
     # The rule templates are
     #   isGrandFather(x,y) -> isFather(*,*) ∧ isFather(*,*) [x,y,z]
@@ -44,17 +65,19 @@ def test_1():
     #   isSibling(x,y):- isFather(z,x) ∧ isFather(z,y)
     #   isSibling(x,y) <-> (isFather(z,x) ∧ isFather(z,y))
 
-    for target in [(P1, ['x, z', 'z, y']),
-                   (P2, ['z, x', 'z, y'])]:
+    for target in [(P1, ["x, z", "z, y"]), (P2, ["z, x", "z, y"])]:
         model = Model()
         b, p = model.add_predicates(2, B[0], target[0][0], world=World.FALSE)
-        model.add_facts({
-            b.name: {pair: TRUE for pair in B[1]},
-            p.name: {pair: TRUE for pair in target[0][1]}})
+        model.add_facts(
+            {
+                b.name: {pair: TRUE for pair in B[1]},
+                p.name: {pair: TRUE for pair in target[0][1]},
+            }
+        )
 
-        x = Variable('x')
-        y = Variable('y')
-        z = Variable('z')
+        x = Variable("x")
+        y = Variable("y")
+        z = Variable("z")
 
         variables = [x, y, z]
         pairs = itertools.permutations(variables, 2)  # e.g. [(x, y), ...]
@@ -64,35 +87,32 @@ def test_1():
         rule_vars = itertools.combinations(pairs, 2)
         rule_vars = list(rule_vars)
 
-        neuron = {
-            'bias_learning': False,
-            'weights_learning': False}
+        neuron = {"bias_learning": False, "weights_learning": False}
 
         subrules = []
         for i, preds_vars in enumerate(rule_vars):
             vars1, vars2 = preds_vars
-            model[str(i)] = ForAll(Bidirectional(And(b(*vars1), b(*vars2),
-                                                     neuron=neuron),
-                                                 p(x, y),
-                                                 neuron=neuron),
-                                   fully_grounded=True)
+            model[str(i)] = ForAll(
+                Bidirectional(
+                    And(b(*vars1), b(*vars2), neuron=neuron), p(x, y), neuron=neuron
+                ),
+                fully_grounded=True,
+            )
             subrules.append(model[str(i)])
 
-        rule = model['rule'] = And(*subrules, world=World.AXIOM,
-                                   neuron={'bias_learning': False})
+        rule = model["rule"] = And(
+            *subrules, world=World.AXIOM, neuron={"bias_learning": False}
+        )
 
-        parameter_history = {'weights': True, 'bias': True}
-        losses = {'contradiction': 1}
+        parameter_history = {"weights": True, "bias": True}
+        losses = {"contradiction": 1}
 
         total_loss, _ = model.train(
-            direction=UPWARD,
-            losses=losses,
-            parameter_history=parameter_history
+            direction=UPWARD, losses=losses, parameter_history=parameter_history
         )
 
         chosen_idx = []
-        weighted_idx = (rule.neuron.weights == 1).nonzero(
-            as_tuple=True)[0]
+        weighted_idx = (rule.neuron.weights == 1).nonzero(as_tuple=True)[0]
         for idx in weighted_idx:
             subrule_forall = rule.operands[idx]
             if subrule_forall.neuron.bounds_table[0][0] == 1:
@@ -103,10 +123,10 @@ def test_1():
                 chosen_idx.append(subrule_and_vars)
 
         num_chosen = len(chosen_idx)
-        assert num_chosen == 1, 'expected 1 got ' + str(num_chosen)
+        assert num_chosen == 1, "expected 1 got " + str(num_chosen)
         assert chosen_idx[0] == target[1], (
-                'expected ' + str(target[1]) +
-                ' got ' + str(chosen_idx[0]))
+            "expected " + str(target[1]) + " got " + str(chosen_idx[0])
+        )
 
 
 def test_2():
@@ -117,26 +137,48 @@ def test_2():
     """
 
     # Constants
-    C = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'}
+    C = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
     # Binary grounding pairs
     groundings = itertools.permutations(C, 2)
     groundings = list(groundings)
 
     # background data (features)
 
-    B = ['isFather', [('a', 'b'), ('b', 'c'), ('d', 'e'),
-                      ('f', 'g'), ('e', 'h'), ('g', 'a'),
-                      ('d', 'f'), ('a', 'j'), ('g', 'i')]]
+    B = [
+        "isFather",
+        [
+            ("a", "b"),
+            ("b", "c"),
+            ("d", "e"),
+            ("f", "g"),
+            ("e", "h"),
+            ("g", "a"),
+            ("d", "f"),
+            ("a", "j"),
+            ("g", "i"),
+        ],
+    ]
 
     # positive (target) labels for isGrandFather(x,y)
 
-    P1 = ['isGrandFather', [('a', 'c'), ('g', 'b'), ('f', 'a'),
-                            ('d', 'g'), ('d', 'h'), ('g', 'j'),
-                            ('f', 'i')]]
+    P1 = [
+        "isGrandFather",
+        [
+            ("a", "c"),
+            ("g", "b"),
+            ("f", "a"),
+            ("d", "g"),
+            ("d", "h"),
+            ("g", "j"),
+            ("f", "i"),
+        ],
+    ]
 
     # positive (target) labels for isSibling(x,y)
-    P2 = ['isSibling', [('j', 'b'), ('b', 'j'), ('a', 'i'),
-                        ('i', 'a'), ('f', 'e'), ('e', 'f')]]
+    P2 = [
+        "isSibling",
+        [("j", "b"), ("b", "j"), ("a", "i"), ("i", "a"), ("f", "e"), ("e", "f")],
+    ]
 
     # The rule templates are
     #   isGrandFather(x,y) -> isFather(*,*) ∧ isFather(*,*) [x,y,z]
@@ -149,22 +191,24 @@ def test_2():
     #   isSibling(x,y):- isFather(z,x) ∧ isFather(z,y)
     #   isSibling(x,y) <-> (isFather(z,x) ∧ isFather(z,y))
 
-    for target in [(P1, ['x, z', 'z, y']),
-                   (P2, ['z, x', 'z, y'])]:
+    for target in [(P1, ["x, z", "z, y"]), (P2, ["z, x", "z, y"])]:
         model = Model()
         b, p = model.add_predicates(2, B[0], target[0][0], world=World.FALSE)
-        model.add_facts({
-            b.name: {pair: TRUE for pair in B[1]},
-            p.name: {pair: TRUE for pair in target[0][1]}})
+        model.add_facts(
+            {
+                b.name: {pair: TRUE for pair in B[1]},
+                p.name: {pair: TRUE for pair in target[0][1]},
+            }
+        )
 
         # Negative facts
-        model.add_facts({
-            p.name: {pair: FALSE for pair in groundings
-                     if pair not in target[0][1]}})
+        model.add_facts(
+            {p.name: {pair: FALSE for pair in groundings if pair not in target[0][1]}}
+        )
 
-        x = Variable('x')
-        y = Variable('y')
-        z = Variable('z')
+        x = Variable("x")
+        y = Variable("y")
+        z = Variable("z")
 
         variables = [x, y, z]
         pairs = itertools.permutations(variables, 2)  # e.g. [(x, y), ...]
@@ -174,34 +218,30 @@ def test_2():
         rule_vars = itertools.combinations(pairs, 2)
         rule_vars = list(rule_vars)
 
-        neuron = {
-            'bias_learning': False,
-            'weights_learning': False}
+        neuron = {"bias_learning": False, "weights_learning": False}
 
         subrules = []
         for i, preds_vars in enumerate(rule_vars):
             vars1, vars2 = preds_vars
-            model[str(i)] = ForAll(Bidirectional(And(b(*vars1), b(*vars2),
-                                                     neuron=neuron),
-                                                 p(x, y),
-                                                 neuron=neuron),
-                                   fully_grounded=True)
+            model[str(i)] = ForAll(
+                Bidirectional(
+                    And(b(*vars1), b(*vars2), neuron=neuron), p(x, y), neuron=neuron
+                ),
+                fully_grounded=True,
+            )
             subrules.append(model[str(i)])
 
-        rule = model['rule'] = And(*subrules, world=World.AXIOM)
+        rule = model["rule"] = And(*subrules, world=World.AXIOM)
 
-        parameter_history = {'weights': True, 'bias': True}
-        losses = {'contradiction': 1}
+        parameter_history = {"weights": True, "bias": True}
+        losses = {"contradiction": 1}
 
         total_loss, _ = model.train(
-            direction=UPWARD,
-            losses=losses,
-            parameter_history=parameter_history
+            direction=UPWARD, losses=losses, parameter_history=parameter_history
         )
 
         chosen_idx = []
-        weighted_idx = (rule.neuron.weights == 1).nonzero(
-            as_tuple=True)[0]
+        weighted_idx = (rule.neuron.weights == 1).nonzero(as_tuple=True)[0]
         for idx in weighted_idx:
             subrule_forall = rule.operands[idx]
             if subrule_forall.neuron.bounds_table[0][0] == 1:
@@ -212,11 +252,15 @@ def test_2():
                 chosen_idx.append(subrule_and_vars)
 
         num_chosen = len(chosen_idx)
-        assert num_chosen == 1, 'expected 1 got ' + str(num_chosen)
+        assert num_chosen == 1, "expected 1 got " + str(num_chosen)
         assert chosen_idx[0] == target[1], (
-                'expected ' + str(target[1]) +
-                ' got ' + str(chosen_idx[0]) +
-                ' from ' + str(chosen_idx))
+            "expected "
+            + str(target[1])
+            + " got "
+            + str(chosen_idx[0])
+            + " from "
+            + str(chosen_idx)
+        )
 
 
 def test_3():
@@ -227,26 +271,48 @@ def test_3():
     """
 
     # Constants
-    C = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'}
+    C = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
     # Binary grounding pairs
     groundings = itertools.permutations(C, 2)
     groundings = list(groundings)
 
     # background data (features)
 
-    B = ['isFather', [('a', 'b'), ('b', 'c'), ('d', 'e'),
-                      ('f', 'g'), ('e', 'h'), ('g', 'a'),
-                      ('d', 'f'), ('a', 'j'), ('g', 'i')]]
+    B = [
+        "isFather",
+        [
+            ("a", "b"),
+            ("b", "c"),
+            ("d", "e"),
+            ("f", "g"),
+            ("e", "h"),
+            ("g", "a"),
+            ("d", "f"),
+            ("a", "j"),
+            ("g", "i"),
+        ],
+    ]
 
     # positive (target) labels for isGrandFather(x,y)
 
-    P1 = ['isGrandFather', [('a', 'c'), ('g', 'b'), ('f', 'a'),
-                            ('d', 'g'), ('d', 'h'), ('g', 'j'),
-                            ('f', 'i')]]
+    P1 = [
+        "isGrandFather",
+        [
+            ("a", "c"),
+            ("g", "b"),
+            ("f", "a"),
+            ("d", "g"),
+            ("d", "h"),
+            ("g", "j"),
+            ("f", "i"),
+        ],
+    ]
 
     # positive (target) labels for isSibling(x,y)
-    P2 = ['isSibling', [('j', 'b'), ('b', 'j'), ('a', 'i'),
-                        ('i', 'a'), ('f', 'e'), ('e', 'f')]]
+    P2 = [
+        "isSibling",
+        [("j", "b"), ("b", "j"), ("a", "i"), ("i", "a"), ("f", "e"), ("e", "f")],
+    ]
 
     # The rule templates are
     #   isGrandFather(x,y) -> isFather(*,*) ∧ isFather(*,*) [x,y,z]
@@ -259,22 +325,25 @@ def test_3():
     #   isSibling(x,y):- isFather(z,x) ∧ isFather(z,y)
     #   isSibling(x,y) <-> (isFather(z,x) ∧ isFather(z,y))
 
-    for target in [(P1, ['x, z', 'z, y']),
-                   (P2, ['z, x', 'z, y'])]:
+    for target in [(P1, ["x, z", "z, y"]), (P2, ["z, x", "z, y"])]:
         model = Model()
         b, p = model.add_predicates(2, B[0], target[0][0], world=World.FALSE)
-        model.add_facts({
-            b.name: {pair: TRUE for pair in B[1][0:-2]},
-            p.name: {pair: TRUE for pair in target[0][1]}})
+        model.add_facts(
+            {
+                b.name: {pair: TRUE for pair in B[1][0:-2]},
+                p.name: {pair: TRUE for pair in target[0][1]},
+            }
+        )
 
         # Negative facts
         neg_facts = [pair for pair in groundings if pair not in target[0][1]]
-        model.add_facts({
-            p.name: {pair: FALSE for pair in random.choices(neg_facts, k=7)}})
+        model.add_facts(
+            {p.name: {pair: FALSE for pair in random.choices(neg_facts, k=7)}}
+        )
 
-        x = Variable('x')
-        y = Variable('y')
-        z = Variable('z')
+        x = Variable("x")
+        y = Variable("y")
+        z = Variable("z")
 
         variables = [x, y, z]
         pairs = itertools.permutations(variables, 2)  # e.g. [(x, y), ...]
@@ -287,34 +356,30 @@ def test_3():
         rule_vars = itertools.combinations(pairs, 2)
         rule_vars = list(rule_vars)
 
-        neuron = {
-            'bias_learning': False,
-            'weights_learning': False}
+        neuron = {"bias_learning": False, "weights_learning": False}
 
         subrules = []
         for i, preds_vars in enumerate(rule_vars):
             vars1, vars2 = preds_vars
-            model[str(i)] = ForAll(Bidirectional(And(b(*vars1), b(*vars2),
-                                                     neuron=neuron),
-                                                 p(x, y),
-                                                 neuron=neuron),
-                                   fully_grounded=True)
+            model[str(i)] = ForAll(
+                Bidirectional(
+                    And(b(*vars1), b(*vars2), neuron=neuron), p(x, y), neuron=neuron
+                ),
+                fully_grounded=True,
+            )
             subrules.append(model[str(i)])
 
-        rule = model['rule'] = And(*subrules, world=World.AXIOM)
+        rule = model["rule"] = And(*subrules, world=World.AXIOM)
 
-        parameter_history = {'weights': True, 'bias': True}
-        losses = {'contradiction': 1}
+        parameter_history = {"weights": True, "bias": True}
+        losses = {"contradiction": 1}
 
         total_loss, _ = model.train(
-            direction=UPWARD,
-            losses=losses,
-            parameter_history=parameter_history
+            direction=UPWARD, losses=losses, parameter_history=parameter_history
         )
 
         chosen_idx = []
-        weighted_idx = (rule.neuron.weights == 1).nonzero(
-            as_tuple=True)[0]
+        weighted_idx = (rule.neuron.weights == 1).nonzero(as_tuple=True)[0]
         for idx in weighted_idx:
             subrule_forall = rule.operands[idx]
             if subrule_forall.neuron.bounds_table[0][0] == 1:
@@ -326,16 +391,19 @@ def test_3():
 
         rule.print(params=True)
         num_chosen = len(chosen_idx)
-        assert num_chosen == 1, (
-                f'expected 1 got {num_chosen} in {chosen_idx}')
+        assert num_chosen == 1, f"expected 1 got {num_chosen} in {chosen_idx}"
         assert chosen_idx[0] == target[1], (
-                'expected ' + str(target[1]) +
-                ' got ' + str(chosen_idx[0]) +
-                ' from ' + str(chosen_idx))
+            "expected "
+            + str(target[1])
+            + " got "
+            + str(chosen_idx[0])
+            + " from "
+            + str(chosen_idx)
+        )
 
 
 if __name__ == "__main__":
     test_1()
     test_2()
     test_3()
-    print('success')
+    print("success")

--- a/tests/learning/lifted/grecian_1.py
+++ b/tests/learning/lifted/grecian_1.py
@@ -12,11 +12,11 @@ def test():
     model = Model()
 
     # define the rules/knowledge
-    Grecian = model['G'] = Predicate()
-    Human = model['H'] = Predicate()
-    Mortal = model['M'] = Predicate()
-    Lived = model['L'] = Predicate()
-    Alive = model['A'] = Predicate()
+    Grecian = model["G"] = Predicate()
+    Human = model["H"] = Predicate()
+    Mortal = model["M"] = Predicate()
+    Lived = model["L"] = Predicate()
+    Alive = model["A"] = Predicate()
 
     formulae = [
         Grecian.Implies(Human),
@@ -30,12 +30,13 @@ def test():
     model.print()
     plot_graph(model)
 
-    GT = ['(G → M)', '(H → (L ∨ A))', '(G → (L ∨ A))']
+    GT = ["(G → M)", "(H → (L ∨ A))", "(G → (L ∨ A))"]
     for gt in GT:
-        assert gt in model.nodes.keys(), (
-            f'lifted preprocessing could not find {gt} in the model')
+        assert (
+            gt in model.nodes.keys()
+        ), f"lifted preprocessing could not find {gt} in the model"
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/learning/lifted/teaches.py
+++ b/tests/learning/lifted/teaches.py
@@ -4,24 +4,25 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, Predicate, Variable, Implies, And, plot_graph,
-                 AXIOM, CLOSED)
+from lnn import Model, Predicate, Variable, Implies, And, plot_graph, AXIOM, CLOSED
 
 
 model = Model()
 
 # define the rules/knowledge
 teacher, student, course, company = map(
-    Variable, ('teacher', 'student', 'course', 'company'))
+    Variable, ("teacher", "student", "course", "company")
+)
 
-Teaches = model['Teaches'] = Predicate(arity=2, world=AXIOM)
-Takes = model['Takes'] = Predicate(arity=2, world=AXIOM)
-JobOffers = model['JobOffers'] = Predicate(arity=2, world=CLOSED)
+Teaches = model["Teaches"] = Predicate(arity=2, world=AXIOM)
+Takes = model["Takes"] = Predicate(arity=2, world=AXIOM)
+JobOffers = model["JobOffers"] = Predicate(arity=2, world=CLOSED)
 
-model['Teaches_Take_JobOffers'] = Implies(
+model["Teaches_Take_JobOffers"] = Implies(
     And(Teaches(teacher, course), Takes(student, course)),
     JobOffers(student, company),
-    world=AXIOM)
+    world=AXIOM,
+)
 
 model.infer(lifted=True)
 model.print()

--- a/tests/learning/propositional/test_bidirectional_1.py
+++ b/tests/learning/propositional/test_bidirectional_1.py
@@ -14,14 +14,16 @@ def test_1():
     training in the upward direction
     """
     model = Model()
-    A, B = model.add_propositions('A', 'B')
-    AB = A.Bidirectional(B, name='A <-> B')
+    A, B = model.add_propositions("A", "B")
+    AB = A.Bidirectional(B, name="A <-> B")
     model.add_formulae(AB)
     for rows in truth_table(2):
-        model.add_facts({
-            A.name: rows[0],
-            B.name: rows[1],
-        })
+        model.add_facts(
+            {
+                A.name: rows[0],
+                B.name: rows[1],
+            }
+        )
         model.upward()
         model[AB.name].print()
         model.flush()

--- a/tests/learning/propositional/test_bool_and_1.py
+++ b/tests/learning/propositional/test_bool_and_1.py
@@ -19,28 +19,23 @@ def test_1():
     model = Model()
 
     # rules
-    model['A'] = Proposition('A')
-    model['B'] = Proposition('B')
-    model['AB'] = And(model['A'], model['B'], world=World.AXIOM)
+    model["A"] = Proposition("A")
+    model["B"] = Proposition("B")
+    model["AB"] = And(model["A"], model["B"], world=World.AXIOM)
 
     # facts
-    model.add_facts({
-        'A': TRUE,
-        'B': FALSE
-    })
+    model.add_facts({"A": TRUE, "B": FALSE})
 
     # train/inference
-    model.train(
-        direction=UPWARD,
-        losses={'contradiction': 1})
+    model.train(direction=UPWARD, losses={"contradiction": 1})
     model.print(params=True)
 
-    weights = model['AB'].params('weights')
-    bounds = model['B'].state()
-    assert weights[1] <= 1/2, (
-        f'expected input B to be downweighted <= 0., received {weights[1]}')
-    assert bounds is FALSE, (
-        f'expected bounds to remain False, received {bounds}')
+    weights = model["AB"].params("weights")
+    bounds = model["B"].state()
+    assert (
+        weights[1] <= 1 / 2
+    ), f"expected input B to be downweighted <= 0., received {weights[1]}"
+    assert bounds is FALSE, f"expected bounds to remain False, received {bounds}"
 
 
 def test_2():
@@ -50,22 +45,22 @@ def test_2():
     training in both directions
     """
     model = Model()
-    model['A'] = Proposition('A')
-    model['B'] = Proposition('B')
-    model['AB'] = And(model['A'], model['B'], world=World.AXIOM,)
-    model.add_facts({
-        'A': TRUE,
-        'B': FALSE
-    })
-    model.train(
-        losses={'contradiction': 1})
+    model["A"] = Proposition("A")
+    model["B"] = Proposition("B")
+    model["AB"] = And(
+        model["A"],
+        model["B"],
+        world=World.AXIOM,
+    )
+    model.add_facts({"A": TRUE, "B": FALSE})
+    model.train(losses={"contradiction": 1})
 
-    weights = model['AB'].params('weights')
-    bounds = model['B'].state()
-    assert weights[1] <= 1/2, (
-        f'expected input B to be downweighted <= 0., received {weights[1]}')
-    assert bounds is FALSE, (
-        f'expected bounds to remain False, received {bounds}')
+    weights = model["AB"].params("weights")
+    bounds = model["B"].state()
+    assert (
+        weights[1] <= 1 / 2
+    ), f"expected input B to be downweighted <= 0., received {weights[1]}"
+    assert bounds is FALSE, f"expected bounds to remain False, received {bounds}"
 
 
 def test_3():
@@ -75,24 +70,24 @@ def test_3():
     training in both directions
     """
     model = Model()
-    model['A'] = Proposition()
-    model['B'] = Proposition()
-    model['C'] = Proposition()
-    model['and'] = And(model['A'], model['B'], model['C'], world=World.AXIOM,)
-    model.add_facts({
-        'A': TRUE,
-        'B': FALSE,
-        'C': TRUE
-    })
-    model.train(
-        losses={'contradiction': 1})
+    model["A"] = Proposition()
+    model["B"] = Proposition()
+    model["C"] = Proposition()
+    model["and"] = And(
+        model["A"],
+        model["B"],
+        model["C"],
+        world=World.AXIOM,
+    )
+    model.add_facts({"A": TRUE, "B": FALSE, "C": TRUE})
+    model.train(losses={"contradiction": 1})
 
-    weights = model['and'].params('weights')
-    bounds = model['B'].state()
-    assert weights[1] <= 1/2, (
-        f'expected input B to be downweighted <= 0., received {weights[1]}')
-    assert bounds is FALSE, (
-        f'expected bounds to remain False, received {bounds}')
+    weights = model["and"].params("weights")
+    bounds = model["B"].state()
+    assert (
+        weights[1] <= 1 / 2
+    ), f"expected input B to be downweighted <= 0., received {weights[1]}"
+    assert bounds is FALSE, f"expected bounds to remain False, received {bounds}"
 
 
 def test_multiple():
@@ -105,35 +100,37 @@ def test_multiple():
     for n in inputs:
         r = n - 1
         model = Model()
-        neuron = {'alpha': 1-1e-5}
-        prop = [f'P{i}' for i in range(n)]
+        neuron = {"alpha": 1 - 1e-5}
+        prop = [f"P{i}" for i in range(n)]
         truths = [TRUE] * n
         truths[:r] = [FALSE] * r
         truths = random.sample(truths, n)
         from tqdm import tqdm
+
         for idx, p in tqdm(
-                enumerate(prop),
-                desc='populating graph',
-                total=n,
-                disable=True):
-            model[f'{p}'] = Proposition(neuron=neuron)
-            model.add_facts({f'{p}': truths[idx]})
-        model['and'] = And(*[model[f'{p}'] for p in prop],
-                           world=World.AXIOM, neuron=neuron)
-        model.train(losses=['contradiction'], learning_rate=1e-1)
+            enumerate(prop), desc="populating graph", total=n, disable=True
+        ):
+            model[f"{p}"] = Proposition(neuron=neuron)
+            model.add_facts({f"{p}": truths[idx]})
+        model["and"] = And(
+            *[model[f"{p}"] for p in prop], world=World.AXIOM, neuron=neuron
+        )
+        model.train(losses=["contradiction"], learning_rate=1e-1)
         model.print(params=True)
 
         # test operator bounds
-        prediction = model['and'].state()
-        assert prediction is TRUE, f"received {prediction} " \
-                                   f"{model['and'].get_facts().tolist()}"
+        prediction = model["and"].state()
+        assert prediction is TRUE, (
+            f"received {prediction} " f"{model['and'].get_facts().tolist()}"
+        )
 
         # test operator weights
         false_idxs = [idx for idx, truth in enumerate(truths) if not truth]
-        weights = model['and'].params('weights', detach=True).numpy()
+        weights = model["and"].params("weights", detach=True).numpy()
         for w in weights[false_idxs]:
-            assert w <= .5 + 1e-5, (
-                f'expected False input to be downweighted <= 1., received {w}')
+            assert (
+                w <= 0.5 + 1e-5
+            ), f"expected False input to be downweighted <= 1., received {w}"
 
 
 def test_bias():
@@ -143,15 +140,17 @@ def test_bias():
     """
     model = Model()
     n = 1000
-    prop = [f'P{i}' for i in range(n)]
+    prop = [f"P{i}" for i in range(n)]
     for p in prop:
-        model[f'{p}'] = Proposition()
-        model.add_facts({f'{p}': TRUE})
-    model['and'] = And(*[model[f'{p}'] for p in prop], world=CLOSED,)
-    model.train(losses={'contradiction': 1})
-    bias = model['and'].params('bias')
-    assert bias <= 1e-5, (
-         f'expected bias <= 0, received {bias}')
+        model[f"{p}"] = Proposition()
+        model.add_facts({f"{p}": TRUE})
+    model["and"] = And(
+        *[model[f"{p}"] for p in prop],
+        world=CLOSED,
+    )
+    model.train(losses={"contradiction": 1})
+    bias = model["and"].params("bias")
+    assert bias <= 1e-5, f"expected bias <= 0, received {bias}"
 
 
 def test_all():
@@ -161,18 +160,21 @@ def test_all():
     """
     model = Model()
     n = 1000
-    prop = [f'P{i}' for i in range(n)]
+    prop = [f"P{i}" for i in range(n)]
     for p in prop:
-        model[f'{p}'] = Proposition()
-        model.add_facts({f'{p}': FALSE})
-    model['and'] = And(*[model[f'{p}'] for p in prop], world=World.AXIOM,)
-    model.train(losses={'contradiction': 1})
-    bounds = model['and'].state()
-    assert bounds is TRUE, (
-        f'expected bounds to remain True, received {bounds}')
-    weights = model['and'].params('weights')
-    assert all([w <= .5 + 1e-5 for w in weights]), (
-        f'expected all inputs to be downweighted (±0.0), received {weights}')
+        model[f"{p}"] = Proposition()
+        model.add_facts({f"{p}": FALSE})
+    model["and"] = And(
+        *[model[f"{p}"] for p in prop],
+        world=World.AXIOM,
+    )
+    model.train(losses={"contradiction": 1})
+    bounds = model["and"].state()
+    assert bounds is TRUE, f"expected bounds to remain True, received {bounds}"
+    weights = model["and"].params("weights")
+    assert all(
+        [w <= 0.5 + 1e-5 for w in weights]
+    ), f"expected all inputs to be downweighted (±0.0), received {weights}"
 
 
 if __name__ == "__main__":
@@ -182,4 +184,4 @@ if __name__ == "__main__":
     test_multiple()
     test_bias()
     test_all()
-    print('success')
+    print("success")

--- a/tests/learning/propositional/test_bool_implies_1.py
+++ b/tests/learning/propositional/test_bool_implies_1.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, Implies, Proposition, World,
-                 UPWARD, TRUE, FALSE, UNKNOWN, CLOSED)
+from lnn import Model, Implies, Proposition, World, UPWARD, TRUE, FALSE, UNKNOWN, CLOSED
 
 
 def test_true_operator():
@@ -24,23 +23,16 @@ def test_true_operator():
         the operator is incorrect
     """
     model = Model()
-    model['LHS'] = Proposition('LHS')
-    model['RHS'] = Proposition('RHS')
-    model['AB'] = Implies(model['LHS'], model['RHS'], world=World.AXIOM)
-    model.add_facts({
-        'LHS': TRUE,
-        'RHS': FALSE
-    })
-    model.train(
-        direction=UPWARD,
-        losses=['contradiction'])
+    model["LHS"] = Proposition("LHS")
+    model["RHS"] = Proposition("RHS")
+    model["AB"] = Implies(model["LHS"], model["RHS"], world=World.AXIOM)
+    model.add_facts({"LHS": TRUE, "RHS": FALSE})
+    model.train(direction=UPWARD, losses=["contradiction"])
     model.print(params=True)
-    bias = model['AB'].params('bias')
-    bounds = model['AB'].state()
-    assert bias <= 1e-5, (
-        f'expected bias to be downweighted <= 0., received {bias}')
-    assert bounds is TRUE, (
-        f'expected operator bounds to remain True, received {bounds}')
+    bias = model["AB"].params("bias")
+    bounds = model["AB"].state()
+    assert bias <= 1e-5, f"expected bias to be downweighted <= 0., received {bias}"
+    assert bounds is TRUE, f"expected operator bounds to remain True, received {bounds}"
 
 
 def test_false_operator_1():
@@ -50,24 +42,18 @@ def test_false_operator_1():
     expects LHS innput to be downweighted
     """
     model = Model()
-    neuron = {'alpha': 1-1e-5}
-    model['LHS'] = Proposition('LHS')
-    model['RHS'] = Proposition('RHS')
-    model['AB'] = Implies(model['LHS'], model['RHS'],
-                          world=CLOSED, neuron=neuron)
-    model.add_facts({
-        'LHS': FALSE,
-        'RHS': UNKNOWN
-    })
-    model.train(
-        direction=UPWARD,
-        losses=['contradiction'])
-    weights = model['AB'].params('weights')
-    bounds = model['AB'].state()
-    assert weights[0] <= 1/2, (
-        f'expected input LHS to be downweighted <= .5, received {weights[0]}')
-    assert bounds is FALSE, (
-        f'expected bounds AB to remain False, received {bounds}')
+    neuron = {"alpha": 1 - 1e-5}
+    model["LHS"] = Proposition("LHS")
+    model["RHS"] = Proposition("RHS")
+    model["AB"] = Implies(model["LHS"], model["RHS"], world=CLOSED, neuron=neuron)
+    model.add_facts({"LHS": FALSE, "RHS": UNKNOWN})
+    model.train(direction=UPWARD, losses=["contradiction"])
+    weights = model["AB"].params("weights")
+    bounds = model["AB"].state()
+    assert (
+        weights[0] <= 1 / 2
+    ), f"expected input LHS to be downweighted <= .5, received {weights[0]}"
+    assert bounds is FALSE, f"expected bounds AB to remain False, received {bounds}"
 
 
 def test_false_operator_2():
@@ -81,23 +67,18 @@ def test_false_operator_2():
         - both LHS and RHS add information, and are therefore incorrect
     """
     model = Model()
-    model['LHS'] = Proposition('LHS')
-    model['RHS'] = Proposition('RHS')
-    model['AB'] = Implies(model['LHS'], model['RHS'], world=CLOSED)
-    model.add_facts({
-        'LHS': FALSE,
-        'RHS': TRUE
-    })
-    model.train(
-        direction=UPWARD,
-        losses=['contradiction'])
+    model["LHS"] = Proposition("LHS")
+    model["RHS"] = Proposition("RHS")
+    model["AB"] = Implies(model["LHS"], model["RHS"], world=CLOSED)
+    model.add_facts({"LHS": FALSE, "RHS": TRUE})
+    model.train(direction=UPWARD, losses=["contradiction"])
 
-    weights = model['AB'].params('weights')
-    bounds = model['AB'].state()
-    assert all([w <= 1/2 for w in weights]), (
-        f'expected both inputs to be downweighted <= .5, received {weights}')
-    assert bounds is FALSE, (
-        f'expected bounds AB to remain False, received {bounds}')
+    weights = model["AB"].params("weights")
+    bounds = model["AB"].state()
+    assert all(
+        [w <= 1 / 2 for w in weights]
+    ), f"expected both inputs to be downweighted <= .5, received {weights}"
+    assert bounds is FALSE, f"expected bounds AB to remain False, received {bounds}"
 
 
 def test_false_operator_3():
@@ -109,24 +90,18 @@ def test_false_operator_3():
     of the contradiction - downweight RHS
     """
     model = Model()
-    neuron = {'alpha': 1 - 1e-5}
-    model['LHS'] = Proposition('LHS')
-    model['RHS'] = Proposition('RHS')
-    model['AB'] = Implies(model['LHS'], model['RHS'],
-                          world=CLOSED, neuron=neuron)
-    model.add_facts({
-        'LHS': TRUE,
-        'RHS': TRUE
-    })
-    model.train(
-        direction=UPWARD,
-        losses=['contradiction'])
-    weights = model['AB'].params('weights')
-    bounds = model['AB'].state()
-    assert weights[1] <= 1/2, (
-        f'expected input RHS to be downweighted <= .5, received {weights[1]}')
-    assert bounds is FALSE, (
-        f'expected bounds AB to remain False, received {bounds}')
+    neuron = {"alpha": 1 - 1e-5}
+    model["LHS"] = Proposition("LHS")
+    model["RHS"] = Proposition("RHS")
+    model["AB"] = Implies(model["LHS"], model["RHS"], world=CLOSED, neuron=neuron)
+    model.add_facts({"LHS": TRUE, "RHS": TRUE})
+    model.train(direction=UPWARD, losses=["contradiction"])
+    weights = model["AB"].params("weights")
+    bounds = model["AB"].state()
+    assert (
+        weights[1] <= 1 / 2
+    ), f"expected input RHS to be downweighted <= .5, received {weights[1]}"
+    assert bounds is FALSE, f"expected bounds AB to remain False, received {bounds}"
 
 
 if __name__ == "__main__":
@@ -134,4 +109,4 @@ if __name__ == "__main__":
     test_false_operator_1()
     test_false_operator_2()
     test_false_operator_3()
-    print('success')
+    print("success")

--- a/tests/learning/propositional/test_bool_or_1.py
+++ b/tests/learning/propositional/test_bool_or_1.py
@@ -13,25 +13,24 @@ def test_upward():
     given And(A, B) - reduce the weight on B
     """
     model = Model()
-    model['A'] = Proposition('A')
-    model['B'] = Proposition('B')
-    model['AB'] = Or(model['A'], model['B'], world=CLOSED,)
-    model.add_facts({
-        'A': TRUE,
-        'B': FALSE
-    })
-    model.train(
-        direction=UPWARD,
-        losses={'contradiction': .1})
+    model["A"] = Proposition("A")
+    model["B"] = Proposition("B")
+    model["AB"] = Or(
+        model["A"],
+        model["B"],
+        world=CLOSED,
+    )
+    model.add_facts({"A": TRUE, "B": FALSE})
+    model.train(direction=UPWARD, losses={"contradiction": 0.1})
 
-    weights = model['AB'].params('weights')
-    bounds = model['A'].state()
-    assert weights[0] <= .5, (
-        f'expected input A to be downweighted <= 0., received {weights[0]}')
-    assert bounds is TRUE, (
-        f'expected bounds to remain True, received {bounds}')
+    weights = model["AB"].params("weights")
+    bounds = model["A"].state()
+    assert (
+        weights[0] <= 0.5
+    ), f"expected input A to be downweighted <= 0., received {weights[0]}"
+    assert bounds is TRUE, f"expected bounds to remain True, received {bounds}"
 
 
 if __name__ == "__main__":
     test_upward()
-    print('success')
+    print("success")

--- a/tests/learning/propositional/test_logical_1.py
+++ b/tests/learning/propositional/test_logical_1.py
@@ -4,29 +4,24 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, Proposition, And, Or, TRUE, FALSE,
-                 plot_loss, plot_params)
+from lnn import Model, Proposition, And, Or, TRUE, FALSE, plot_loss, plot_params
 
 
 def test_1():
     model = Model()
-    model['A'] = Proposition()
-    model['B'] = Proposition()
-    AB = model['A&B'] = And(model['A'], model['B'])
-    model['A|B'] = Or(model['A'], model['B'])
+    model["A"] = Proposition()
+    model["B"] = Proposition()
+    AB = model["A&B"] = And(model["A"], model["B"])
+    model["A|B"] = Or(model["A"], model["B"])
 
-    model.add_facts({'A': TRUE})
-    model.add_facts({'B': FALSE})
+    model.add_facts({"A": TRUE})
+    model.add_facts({"B": FALSE})
     model.add_labels({AB.name: TRUE})
 
-    parameter_history = {
-        'weights': AB,
-        'bias': AB}
-    losses = ['logical', 'supervised']
+    parameter_history = {"weights": AB, "bias": AB}
+    losses = ["logical", "supervised"]
     total_loss, _ = model.train(
-        losses=losses,
-        learning_rate=.1,
-        parameter_history=parameter_history
+        losses=losses, learning_rate=0.1, parameter_history=parameter_history
     )
     model.print(params=True)
     return total_loss, losses, model
@@ -36,4 +31,4 @@ if __name__ == "__main__":
     total_loss, losses, model = test_1()
     plot_loss(total_loss, losses)
     plot_params(model)
-    print('success')
+    print("success")

--- a/tests/learning/propositional/test_simple_graph_1.py
+++ b/tests/learning/propositional/test_simple_graph_1.py
@@ -9,29 +9,27 @@ from lnn import Model, And, Or, Proposition, World, TRUE, FALSE
 
 def test_1():
     model = Model()
-    model['A'] = Proposition('A')
-    model['B'] = Proposition('B')
-    model['A&B'] = And(model['A'], model['B'], world=World.AXIOM)
-    model['A|B'] = Or(model['A'], model['B'])
-    model.add_facts({'A': TRUE})
-    model.add_facts({'B': FALSE})
-    model.train(
-        epochs=11,
-        losses={'contradiction': 1})
+    model["A"] = Proposition("A")
+    model["B"] = Proposition("B")
+    model["A&B"] = And(model["A"], model["B"], world=World.AXIOM)
+    model["A|B"] = Or(model["A"], model["B"])
+    model.add_facts({"A": TRUE})
+    model.add_facts({"B": FALSE})
+    model.train(epochs=11, losses={"contradiction": 1})
     model.print(params=True)
 
-    weights_and = model['A&B'].params('weights')[1]
-    weights_or, bias_or = model['A|B'].params('weights', 'bias')
-    bounds = model['B'].state()
-    assert model['A|B'].is_unweighted(), (
-        'expected A|B to be unweighted, received '
-        f'w: {weights_or}, b: {bias_or}')
-    assert weights_and <= 1/2, (
-        f'expected input B in A&B to be downweighted, received {weights_and}')
-    assert bounds is FALSE, (
-        f'expected bounds to remain False, received {bounds}')
+    weights_and = model["A&B"].params("weights")[1]
+    weights_or, bias_or = model["A|B"].params("weights", "bias")
+    bounds = model["B"].state()
+    assert model["A|B"].is_unweighted(), (
+        "expected A|B to be unweighted, received " f"w: {weights_or}, b: {bias_or}"
+    )
+    assert (
+        weights_and <= 1 / 2
+    ), f"expected input B in A&B to be downweighted, received {weights_and}"
+    assert bounds is FALSE, f"expected bounds to remain False, received {bounds}"
 
 
 if __name__ == "__main__":
     test_1()
-    print('success')
+    print("success")

--- a/tests/learning/propositional/test_supervised_1.py
+++ b/tests/learning/propositional/test_supervised_1.py
@@ -4,70 +4,74 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, Proposition, And, Or, Implies,
-                 TRUE, FALSE, World, plot_params, plot_loss)
+from lnn import (
+    Model,
+    Proposition,
+    And,
+    Or,
+    Implies,
+    TRUE,
+    FALSE,
+    World,
+    plot_params,
+    plot_loss,
+)
 
 
 def test_1():
     """test supervised, contradiction and logical loss for all neurons"""
     model = Model()
-    A = model['A'] = Proposition()
-    B = model['B'] = Proposition()
-    model['A|B'] = Or(A, B,
-                      world=World.FALSE,
-                      neuron={'bias_learning': False})
-    model['A&B'] = And(A, B,
-                       world=World.AXIOM,
-                       neuron={'bias_learning': False})
-    model['A->B'] = Implies(A, B, world=World.FALSE)
+    A = model["A"] = Proposition()
+    B = model["B"] = Proposition()
+    model["A|B"] = Or(A, B, world=World.FALSE, neuron={"bias_learning": False})
+    model["A&B"] = And(A, B, world=World.AXIOM, neuron={"bias_learning": False})
+    model["A->B"] = Implies(A, B, world=World.FALSE)
 
-    model.add_facts({
-        'A': FALSE,
-        'B': TRUE
-    })
-    model.add_labels({
-        'A|B': FALSE,
-        'A&B': TRUE,
-        'A->B': FALSE,
-    })
+    model.add_facts({"A": FALSE, "B": TRUE})
+    model.add_labels(
+        {
+            "A|B": FALSE,
+            "A&B": TRUE,
+            "A->B": FALSE,
+        }
+    )
 
-    parameter_history = {'weights': True, 'bias': True}
-    losses = {
-        'contradiction': 1,
-        'supervised': 1,
-        'logical': 2e-2
-    }
+    parameter_history = {"weights": True, "bias": True}
+    losses = {"contradiction": 1, "supervised": 1, "logical": 2e-2}
     total_loss, _ = model.train(
         epochs=3e2,
         learning_rate=5e-2,
         losses=losses,
-        parameter_history=parameter_history
+        parameter_history=parameter_history,
     )
 
     model.print(params=True)
     plot_params(model)
     plot_loss(total_loss, losses)
 
-    state = model['A|B'].state()
+    state = model["A|B"].state()
     eps = 1e-3
-    assert state is FALSE, f'expected A|B to be FALSE, received {state}'
-    w = model['A|B'].neuron.weights
-    assert 1-eps <= w[0] and 0 <= w[1] <= eps, (
-            f'expected A|B weights to be in [±1, <=.5], received {w}')
+    assert state is FALSE, f"expected A|B to be FALSE, received {state}"
+    w = model["A|B"].neuron.weights
+    assert (
+        1 - eps <= w[0] and 0 <= w[1] <= eps
+    ), f"expected A|B weights to be in [±1, <=.5], received {w}"
 
-    state = model['A&B'].state()
-    assert state is TRUE, f'expected A&B to be TRUE, received {state}'
-    w = model['A&B'].neuron.weights
-    assert 1-eps <= w[1] and 0 <= w[0] <= eps, (
-            f'expected A&B weights to be [<=.5, ±1], received {w}')
+    state = model["A&B"].state()
+    assert state is TRUE, f"expected A&B to be TRUE, received {state}"
+    w = model["A&B"].neuron.weights
+    assert (
+        1 - eps <= w[1] and 0 <= w[0] <= eps
+    ), f"expected A&B weights to be [<=.5, ±1], received {w}"
 
-    state = model['A->B'].state()
-    assert state is FALSE, f'expected A->B to be FALSE, received {state}'
-    w = model['A->B'].neuron.weights
-    assert all((0 <= w) + (w <= eps)), (
-            f'expected A->B weights to be in [0, .5], received {w}')
+    state = model["A->B"].state()
+    assert state is FALSE, f"expected A->B to be FALSE, received {state}"
+    w = model["A->B"].neuron.weights
+    assert all(
+        (0 <= w) + (w <= eps)
+    ), f"expected A->B weights to be in [0, .5], received {w}"
 
 
 if __name__ == "__main__":
     test_1()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/_test_bool_and_4.py
+++ b/tests/reasoning/gm/_test_bool_and_4.py
@@ -8,18 +8,15 @@ from lnn import Predicate, And, Model, Variable, World, TRUE
 
 
 model = Model()
-x, y, z = map(Variable, ('x', 'y', 'z'))
-model['P'] = Predicate()
-model['B'] = Predicate()
-model['And'] = And(model['P'](x), model['B'](x), world=World.AXIOM)
+x, y, z = map(Variable, ("x", "y", "z"))
+model["P"] = Predicate()
+model["B"] = Predicate()
+model["And"] = And(model["P"](x), model["B"](x), world=World.AXIOM)
 
 
-model['P'].add_facts({
-    'Jon': TRUE,
-    'Bob': TRUE})
-model['B'].add_facts({
-    ('James', 'Date1'): 0.4,
-    ('Bob', 'Date2'): TRUE,
-    ('Jon', 'Date1'): TRUE})
+model["P"].add_facts({"Jon": TRUE, "Bob": TRUE})
+model["B"].add_facts(
+    {("James", "Date1"): 0.4, ("Bob", "Date2"): TRUE, ("Jon", "Date1"): TRUE}
+)
 # print(model.infer())
 model.print()

--- a/tests/reasoning/gm/test_bool_and_1.py
+++ b/tests/reasoning/gm/test_bool_and_1.py
@@ -7,8 +7,7 @@
 from functools import reduce
 
 import numpy as np
-from lnn import (Predicate, And, Model, Variable,
-                 truth_table, fact_to_bool, bool_to_fact)
+from lnn import Predicate, And, Model, Variable, truth_table, fact_to_bool, bool_to_fact
 
 
 def test():
@@ -21,24 +20,22 @@ def test():
         GT = reduce(np.logical_and, map(fact_to_bool, row))
 
         # load model and reason over facts
-        x = Variable('x')
+        x = Variable("x")
         model = Model()
-        model['A'] = Predicate()
-        model['B'] = Predicate()
-        model['AB'] = And(model['A'](x), model['B'](x))
+        model["A"] = Predicate()
+        model["B"] = Predicate()
+        model["AB"] = And(model["A"](x), model["B"](x))
 
         # set model facts
-        model.add_facts({
-            'A': {'0': row[0]},
-            'B': {'0': row[1]}
-        })
+        model.add_facts({"A": {"0": row[0]}, "B": {"0": row[1]}})
 
         # evaluate the conjunction
-        model['AB'].upward()
-        prediction = model['AB'].state('0')
-        assert prediction is bool_to_fact(GT), (
-            f'And({row[0]}, {row[1]}) expected {GT}, received {prediction}')
-    print('success')
+        model["AB"].upward()
+        prediction = model["AB"].state("0")
+        assert prediction is bool_to_fact(
+            GT
+        ), f"And({row[0]}, {row[1]}) expected {GT}, received {prediction}"
+    print("success")
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/gm/test_bool_and_2.py
+++ b/tests/reasoning/gm/test_bool_and_2.py
@@ -7,8 +7,7 @@
 from functools import reduce
 
 import numpy as np
-from lnn import (Predicate, And, Model, Variable,
-                 truth_table, fact_to_bool, bool_to_fact)
+from lnn import Predicate, And, Model, Variable, truth_table, fact_to_bool, bool_to_fact
 
 
 def test():
@@ -26,26 +25,27 @@ def test():
 
     # load model and reason over facts
     model = Model()
-    x = Variable('x')
+    x = Variable("x")
 
     for pred in range(n_preds):
-        model[f'P{pred}'] = Predicate()
-    model['AB'] = And(*[model[f'P{pred}'](x) for pred in range(n_preds)])
+        model[f"P{pred}"] = Predicate()
+    model["AB"] = And(*[model[f"P{pred}"](x) for pred in range(n_preds)])
 
     # set model facts
     for pred in range(n_preds):
-        model.add_facts({
-            f'P{pred}': {f'{row}': truth[pred] for row, truth in enumerate(TT)}
-        })
+        model.add_facts(
+            {f"P{pred}": {f"{row}": truth[pred] for row, truth in enumerate(TT)}}
+        )
 
     # evaluate the conjunction
-    model['AB'].upward()
+    model["AB"].upward()
 
     for row in range(len(TT)):
-        prediction = model['AB'].state(str(row))
-        assert prediction is bool_to_fact(GT[row]), (
-            f'And({TT[:,row]}) expected {GT}, received {prediction}')
-    print('success')
+        prediction = model["AB"].state(str(row))
+        assert prediction is bool_to_fact(
+            GT[row]
+        ), f"And({TT[:,row]}) expected {GT}, received {prediction}"
+    print("success")
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/gm/test_bool_and_3.py
+++ b/tests/reasoning/gm/test_bool_and_3.py
@@ -7,8 +7,7 @@
 from functools import reduce
 
 import numpy as np
-from lnn import (Predicate, And, Model, Variable,
-                 truth_table, fact_to_bool, bool_to_fact)
+from lnn import Predicate, And, Model, Variable, truth_table, fact_to_bool, bool_to_fact
 
 
 def test():
@@ -26,28 +25,32 @@ def test():
 
     # load model and reason over facts
     model = Model()
-    x, y = map(Variable, ('x', 'y'))
+    x, y = map(Variable, ("x", "y"))
 
     for pred in range(n_preds):
-        model[f'P{pred}'] = Predicate(arity=2)
-    model['AB'] = And(*[model[f'P{pred}'](x, y) for pred in range(n_preds)])
+        model[f"P{pred}"] = Predicate(arity=2)
+    model["AB"] = And(*[model[f"P{pred}"](x, y) for pred in range(n_preds)])
 
     # set model facts
     for pred in range(n_preds):
-        model.add_facts({
-            f'P{pred}': {(f'{row}', f'{row}'): truth[pred]
-                         for row, truth in enumerate(TT)}
-        })
+        model.add_facts(
+            {
+                f"P{pred}": {
+                    (f"{row}", f"{row}"): truth[pred] for row, truth in enumerate(TT)
+                }
+            }
+        )
 
     # inference
-    model['AB'].upward()
+    model["AB"].upward()
 
     # evaluate the conjunction
     for row in range(len(TT)):
-        prediction = model['AB'].state((str(row), str(row)))
-        assert prediction is bool_to_fact(GT[row]), (
-            f'And({TT[:, row]}) expected {GT}, received {prediction}')
-    print('success')
+        prediction = model["AB"].state((str(row), str(row)))
+        assert prediction is bool_to_fact(
+            GT[row]
+        ), f"And({TT[:, row]}) expected {GT}, received {prediction}"
+    print("success")
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/gm/test_bool_and_4.py
+++ b/tests/reasoning/gm/test_bool_and_4.py
@@ -7,8 +7,7 @@
 from functools import reduce
 
 import numpy as np
-from lnn import (Predicate, And, Model, Variable,
-                 truth_table, fact_to_bool, bool_to_fact)
+from lnn import Predicate, And, Model, Variable, truth_table, fact_to_bool, bool_to_fact
 
 
 def test():
@@ -21,32 +20,32 @@ def test():
 
     # load model and reason over facts
     model = Model()
-    var_labels = tuple(f'x{i}' for i in range(0, n_vars))
+    var_labels = tuple(f"x{i}" for i in range(0, n_vars))
     variables = list(map(Variable, var_labels))
 
     for pred in range(n_preds):
-        model[f'P{pred}'] = Predicate(arity=n_vars)
+        model[f"P{pred}"] = Predicate(arity=n_vars)
 
-    preds = [model[f'P{pred}'](*variables) for pred in range(n_preds)]
-    model['AB'] = And(*preds)
+    preds = [model[f"P{pred}"](*variables) for pred in range(n_preds)]
+    model["AB"] = And(*preds)
 
     # set model facts
     for pred in range(n_preds):
 
-        test_case = {(f'{row}',) * n_vars: truth[pred]
-                     for row, truth in enumerate(TT)}
-        model.add_facts({f'P{pred}': test_case})
+        test_case = {(f"{row}",) * n_vars: truth[pred] for row, truth in enumerate(TT)}
+        model.add_facts({f"P{pred}": test_case})
 
     # inference
-    model['AB'].upward()
+    model["AB"].upward()
 
     # evaluate the conjunction
     for row in range(len(TT)):
         state = (str(row),) * n_vars
-        prediction = model['AB'].state(state)
-        assert prediction is bool_to_fact(GT[row]), (
-            f'And({TT[row]}) expected {GT}, received {prediction}')
-    print('success')
+        prediction = model["AB"].state(state)
+        assert prediction is bool_to_fact(
+            GT[row]
+        ), f"And({TT[row]}) expected {GT}, received {prediction}"
+    print("success")
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/gm/test_bool_and_5.py
+++ b/tests/reasoning/gm/test_bool_and_5.py
@@ -17,22 +17,23 @@ def test_1():
         n_vars = 1000
 
         model = Model()
-        var_labels = tuple(f'x{i}' for i in range(0, n_vars))
+        var_labels = tuple(f"x{i}" for i in range(0, n_vars))
         variables = list(map(Variable, var_labels))
 
-        p0 = model['p0'] = Predicate()
-        p1 = model['p1'] = Predicate(arity=n_vars)
+        p0 = model["p0"] = Predicate()
+        p1 = model["p1"] = Predicate(arity=n_vars)
 
-        model['And'] = And(p0(variables[0]), p1(*variables),
-                           world=World.AXIOM, join=join)
+        model["And"] = And(
+            p0(variables[0]), p1(*variables), world=World.AXIOM, join=join
+        )
 
-        model.add_facts({'p0': {'0': TRUE, '1': TRUE, '2': TRUE}})
-        model.add_facts({'p1': {('0',) * n_vars: TRUE}})
+        model.add_facts({"p0": {"0": TRUE, "1": TRUE, "2": TRUE}})
+        model.add_facts({"p1": {("0",) * n_vars: TRUE}})
 
         model.infer()
-        assert len(model['And'].groundings) == gt, (
-            f"Expected {gt} grounding, "
-            f"received {len(model['And'].groundings)}")
+        assert len(model["And"].groundings) == gt, (
+            f"Expected {gt} grounding, " f"received {len(model['And'].groundings)}"
+        )
 
 
 def test_2():
@@ -43,23 +44,24 @@ def test_2():
         n_vars = 1000
 
         model = Model()
-        var_labels = tuple(f'x{i}' for i in range(0, n_vars))
+        var_labels = tuple(f"x{i}" for i in range(0, n_vars))
         variables = list(map(Variable, var_labels))
 
-        p0 = model['p0'] = Predicate()
-        p1 = model['p1'] = Predicate(arity=n_vars)
+        p0 = model["p0"] = Predicate()
+        p1 = model["p1"] = Predicate(arity=n_vars)
 
         r = random.randrange(0, n_vars)
-        model['And'] = And(p0(variables[r]), p1(*variables),
-                           world=World.AXIOM, join=join)
+        model["And"] = And(
+            p0(variables[r]), p1(*variables), world=World.AXIOM, join=join
+        )
 
-        model.add_facts({'p0': {'0': TRUE, '1': TRUE, '2': TRUE}})
-        model.add_facts({'p1': {('0',) * n_vars: TRUE}})
+        model.add_facts({"p0": {"0": TRUE, "1": TRUE, "2": TRUE}})
+        model.add_facts({"p1": {("0",) * n_vars: TRUE}})
 
         model.infer()
-        assert len(model['And'].groundings) == gt, (
-            f"Expected {gt} grounding, "
-            f"received {len(model['And'].groundings)}")
+        assert len(model["And"].groundings) == gt, (
+            f"Expected {gt} grounding, " f"received {len(model['And'].groundings)}"
+        )
 
 
 def test_3():
@@ -70,27 +72,42 @@ def test_3():
 
     for join, gt in zip([Join.INNER, Join.OUTER], [3, 3]):
         model = Model()
-        var_labels = tuple(f'x{i}' for i in range(0, n_vars))
+        var_labels = tuple(f"x{i}" for i in range(0, n_vars))
         variables = list(map(Variable, var_labels))
 
-        p0 = model['p0'] = Predicate(arity=3)
-        p1 = model['p1'] = Predicate(arity=n_vars)
+        p0 = model["p0"] = Predicate(arity=3)
+        p1 = model["p1"] = Predicate(arity=n_vars)
 
-        model['And'] = And(p0(variables[0], variables[1], variables[2]),
-                           p1(*variables), world=World.AXIOM)
+        model["And"] = And(
+            p0(variables[0], variables[1], variables[2]),
+            p1(*variables),
+            world=World.AXIOM,
+        )
 
-        model.add_facts({'p0': {('0', '0', '0'): TRUE,
-                                ('0', '0', '1'): TRUE,
-                                ('0', '0', '2'): TRUE, }})
+        model.add_facts(
+            {
+                "p0": {
+                    ("0", "0", "0"): TRUE,
+                    ("0", "0", "1"): TRUE,
+                    ("0", "0", "2"): TRUE,
+                }
+            }
+        )
 
-        model.add_facts({'p1': {('0', '0', '0', '0', '0'): TRUE,
-                                ('0', '0', '1', '0', '0'): TRUE,
-                                ('0', '0', '2', '0', '0'): TRUE, }})
+        model.add_facts(
+            {
+                "p1": {
+                    ("0", "0", "0", "0", "0"): TRUE,
+                    ("0", "0", "1", "0", "0"): TRUE,
+                    ("0", "0", "2", "0", "0"): TRUE,
+                }
+            }
+        )
 
         model.infer()
-        assert len(model['And'].groundings) == gt, (
-            f"Expected {gt} groundings, "
-            f"received {len(model['And'].groundings)}")
+        assert len(model["And"].groundings) == gt, (
+            f"Expected {gt} groundings, " f"received {len(model['And'].groundings)}"
+        )
 
 
 def test_4():
@@ -102,30 +119,29 @@ def test_4():
     for join, gt in zip([Join.INNER, Join.OUTER], [3, 3]):
 
         model = Model()
-        var_labels = tuple(f'x{i}' for i in range(0, n_vars))
+        var_labels = tuple(f"x{i}" for i in range(0, n_vars))
         variables = list(map(Variable, var_labels))
 
-        p0 = model['p0'] = Predicate(arity=n_vars)
-        p1 = model['p1'] = Predicate(arity=n_vars)
+        p0 = model["p0"] = Predicate(arity=n_vars)
+        p1 = model["p1"] = Predicate(arity=n_vars)
 
-        model['And'] = And(p0(*variables), p1(*variables),
-                           world=World.AXIOM, join=join)
+        model["And"] = And(p0(*variables), p1(*variables), world=World.AXIOM, join=join)
 
-        key_arr = ['0'] * n_vars
+        key_arr = ["0"] * n_vars
         random_indices = random.sample(range(1, n_vars), 3)
 
         for i in random_indices:
-            key_arr[i] = '1'
+            key_arr[i] = "1"
 
         key = tuple(key_arr)
 
-        model.add_facts({'p0': {key: TRUE, ('0',) * n_vars: TRUE}})
-        model.add_facts({'p1': {key: TRUE, ('1',) * n_vars: TRUE}})
+        model.add_facts({"p0": {key: TRUE, ("0",) * n_vars: TRUE}})
+        model.add_facts({"p1": {key: TRUE, ("1",) * n_vars: TRUE}})
 
         model.infer()
-        assert len(model['And'].groundings) == gt, (
-            f"Expected {gt} groundings, "
-            f"received {len(model['And'].groundings)}")
+        assert len(model["And"].groundings) == gt, (
+            f"Expected {gt} groundings, " f"received {len(model['And'].groundings)}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/gm/test_gm_binding_1.py
+++ b/tests/reasoning/gm/test_gm_binding_1.py
@@ -9,29 +9,35 @@ from lnn import Model, And, Variable, Predicate, TRUE, FALSE
 
 def test():
     model = Model()
-    x, y, z = map(Variable, ('x', 'y', 'z'))
+    x, y, z = map(Variable, ("x", "y", "z"))
 
-    model['p2'] = Predicate('p2', arity=2)
-    p2_facts = dict([
-                     (('s1', 's7'), TRUE),
-                     (('s1', 's6'), TRUE),
-                     (('s2', 's6'), FALSE),
-                     (('s3', 's7'), FALSE),
-                     (('s4', 's6'), TRUE)])
-    model.add_facts({'p2': p2_facts})
+    model["p2"] = Predicate("p2", arity=2)
+    p2_facts = dict(
+        [
+            (("s1", "s7"), TRUE),
+            (("s1", "s6"), TRUE),
+            (("s2", "s6"), FALSE),
+            (("s3", "s7"), FALSE),
+            (("s4", "s6"), TRUE),
+        ]
+    )
+    model.add_facts({"p2": p2_facts})
 
-    model['p2a'] = Predicate('p2a', arity=2)
-    p2a_facts = dict([
-                      (('s1', 's7'), TRUE),
-                      (('s1', 's6'), FALSE),
-                      (('s2', 's5'), FALSE),
-                      (('s4', 's7'), FALSE),
-                      (('s3', 's7'), FALSE),
-                      (('s7', 's6'), TRUE)])
-    model.add_facts({'p2a': p2a_facts})
+    model["p2a"] = Predicate("p2a", arity=2)
+    p2a_facts = dict(
+        [
+            (("s1", "s7"), TRUE),
+            (("s1", "s6"), FALSE),
+            (("s2", "s5"), FALSE),
+            (("s4", "s7"), FALSE),
+            (("s3", "s7"), FALSE),
+            (("s7", "s6"), TRUE),
+        ]
+    )
+    model.add_facts({"p2a": p2a_facts})
 
     # the unbounded case
-    model['p2_and_p2a'] = And(model['p2'](x, y), model['p2a'](x, y))
+    model["p2_and_p2a"] = And(model["p2"](x, y), model["p2a"](x, y))
     # GT = dict([
     #    (('s1', 's7'), TRUE),
     #    (('s1', 's6'), FALSE),
@@ -42,45 +48,43 @@ def test():
     #    (('s4', 's7'), FALSE),
     #     (('s7', 's6'), UNKNOWN)])
 
-    model['p2_and_p2a'].upward()
+    model["p2_and_p2a"].upward()
     # assert all([model['p2_and_p2a'].state(groundings=g) is GT[g]
     #            for g in GT]), "FAILED 😔"
     # assert len(model['p2_and_p2a'].state()) == len(GT), "FAILED 😔"
 
     # One variable bound
-    model['p2_and_p2b'] = And(model['p2'](x, y), model['p2a'](x, (y, 's7')))
+    model["p2_and_p2b"] = And(model["p2"](x, y), model["p2a"](x, (y, "s7")))
     # GT = dict([
     #    (('s1', 's7'), TRUE),
     #    (('s3', 's7'), FALSE),
     #    (('s4', 's7'), FALSE)])
 
-    model['p2_and_p2b'].upward()
+    model["p2_and_p2b"].upward()
     # assert all([model['p2_and_p2b'].state(groundings=g) is GT[g]
     #            for g in GT]), "FAILED 😔"
     # assert len(model['p2_and_p2b'].state()) == len(GT), "FAILED 😔"
 
     # One variable bound to a list
-    model['p2_and_p2c'] = \
-        And(model['p2'](x, y), model['p2a']((x, ['s1', 's2']), (y, 's6')))
+    model["p2_and_p2c"] = And(
+        model["p2"](x, y), model["p2a"]((x, ["s1", "s2"]), (y, "s6"))
+    )
 
     # GT = dict([
     #    (('s1', 's6'), FALSE),
     #    (('s2', 's6'), FALSE)])
-    model['p2_and_p2c'].upward()
+    model["p2_and_p2c"].upward()
     # assert all([model['p2_and_p2c'].state(groundings=g) is GT[g]
     #            for g in GT]), "FAILED 😔"
     # assert len(model['p2_and_p2c'].state()) == len(GT), "FAILED 😔"
 
     # 1 variable vs 2 variables bound
-    model['p1'] = Predicate('p1')
-    model.add_facts({'p1': {
-        's1': TRUE,
-        's2': TRUE,
-        's3': TRUE,
-        's4': FALSE,
-        's10': FALSE}})
-    model['p1_and_p2'] = And(model['p1']((x, ['s1', 's2'])), model['p2'](x, y))
-    model['p1_and_p2'].upward()
+    model["p1"] = Predicate("p1")
+    model.add_facts(
+        {"p1": {"s1": TRUE, "s2": TRUE, "s3": TRUE, "s4": FALSE, "s10": FALSE}}
+    )
+    model["p1_and_p2"] = And(model["p1"]((x, ["s1", "s2"])), model["p2"](x, y))
+    model["p1_and_p2"].upward()
     # GT = dict([
     #    (('s1', 's6'), TRUE),
     #    (('s2', 's6'), FALSE),
@@ -91,16 +95,21 @@ def test():
     # assert len(model['p1_and_p2'].state()) == len(GT), "FAILED 😔"
 
     # 2 variable vs 3 variables bound
-    model['p3'] = Predicate('p3', arity=3)
-    model.add_facts({'p3': {
-        ('s1', 's5', 's3'): TRUE,
-        ('s1', 's4', 's7'): TRUE,
-        ('s1', 's8', 's3'): FALSE,
-        ('s2', 's8', 's6'): TRUE,
-        ('s4', 's6', 's8'): FALSE}})
+    model["p3"] = Predicate("p3", arity=3)
+    model.add_facts(
+        {
+            "p3": {
+                ("s1", "s5", "s3"): TRUE,
+                ("s1", "s4", "s7"): TRUE,
+                ("s1", "s8", "s3"): FALSE,
+                ("s2", "s8", "s6"): TRUE,
+                ("s4", "s6", "s8"): FALSE,
+            }
+        }
+    )
 
-    model['p2_and_p3'] = And(model['p2'](x, y), model['p3'](x, (z, 's4'), y))
-    model['p2_and_p3'].upward()
+    model["p2_and_p3"] = And(model["p2"](x, y), model["p3"](x, (z, "s4"), y))
+    model["p2_and_p3"].upward()
     # GT = dict([
     #    (('s1', 's7', 's4'), TRUE)])
     # assert all([model['p2_and_p3'].state(groundings=g) is GT[g]
@@ -108,13 +117,10 @@ def test():
     # assert len(model['p2_and_p3'].state()) == len(GT), "FAILED 😔"
 
     # 2 variable vs 2 variable reversed, bound
-    model['p2r'] = Predicate('p2r', arity=2)
-    model.add_facts({'p2r': {
-        ('s6', 's2'): TRUE,
-        ('s7', 's1'): FALSE}})
-    model['p2_and_p2r'] = \
-        And(model['p2'](x, y), model['p2r']((y, ['s7', 's3']), x))
-    model['p2_and_p2r'].upward()
+    model["p2r"] = Predicate("p2r", arity=2)
+    model.add_facts({"p2r": {("s6", "s2"): TRUE, ("s7", "s1"): FALSE}})
+    model["p2_and_p2r"] = And(model["p2"](x, y), model["p2r"]((y, ["s7", "s3"]), x))
+    model["p2_and_p2r"].upward()
     # GT = dict([
     #    (('s1', 's7'), FALSE)])
     # assert all([model['p2_and_p2r'].state(groundings=g) is GT[g]
@@ -124,4 +130,4 @@ def test():
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_gm_njoin_1.py
+++ b/tests/reasoning/gm/test_gm_njoin_1.py
@@ -4,128 +4,145 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, And, Variable, Predicate, TRUE, FALSE,
-                 UNKNOWN)
+from lnn import Model, And, Variable, Predicate, TRUE, FALSE, UNKNOWN
 
 
 def test():
     model = Model()
-    x, y, z = map(Variable, ('x', 'y', 'z'))
+    x, y, z = map(Variable, ("x", "y", "z"))
 
     # This is the normal 2 var vs 2 var ; should go thru the memory join
-    model['p2'] = Predicate('p2', arity=2)
-    model.add_facts({'p2': {
-        ('s1', 's7'): TRUE,
-        ('s1', 's6'): TRUE,
-        ('s2', 's6'): FALSE,
-        ('s3', 's7'): FALSE,
-        ('s4', 's6'): TRUE}})
+    model["p2"] = Predicate("p2", arity=2)
+    model.add_facts(
+        {
+            "p2": {
+                ("s1", "s7"): TRUE,
+                ("s1", "s6"): TRUE,
+                ("s2", "s6"): FALSE,
+                ("s3", "s7"): FALSE,
+                ("s4", "s6"): TRUE,
+            }
+        }
+    )
 
-    model['p2a'] = Predicate('p2a', arity=2)
-    model.add_facts({'p2a': {
-        ('s1', 's7'): TRUE,
-        ('s1', 's6'): FALSE,
-        ('s2', 's5'): FALSE,
-        ('s4', 's7'): FALSE,
-        ('s7', 's6'): TRUE}})
+    model["p2a"] = Predicate("p2a", arity=2)
+    model.add_facts(
+        {
+            "p2a": {
+                ("s1", "s7"): TRUE,
+                ("s1", "s6"): FALSE,
+                ("s2", "s5"): FALSE,
+                ("s4", "s7"): FALSE,
+                ("s7", "s6"): TRUE,
+            }
+        }
+    )
 
-    GT = dict([
-       (('s1', 's7'), TRUE),
-       (('s1', 's6'), FALSE),
-       (('s2', 's6'), FALSE),
-       (('s3', 's7'), FALSE),
-       (('s4', 's6'), UNKNOWN),
-       (('s2', 's5'), FALSE),
-       (('s4', 's7'), FALSE),
-       (('s7', 's6'), UNKNOWN)])
+    GT = dict(
+        [
+            (("s1", "s7"), TRUE),
+            (("s1", "s6"), FALSE),
+            (("s2", "s6"), FALSE),
+            (("s3", "s7"), FALSE),
+            (("s4", "s6"), UNKNOWN),
+            (("s2", "s5"), FALSE),
+            (("s4", "s7"), FALSE),
+            (("s7", "s6"), UNKNOWN),
+        ]
+    )
 
-    model['p2_and_p2a'] = And(model['p2'](x, y), model['p2a'](x, y))
-    model['p2_and_p2a'].upward()
-    assert all([model['p2_and_p2a'].state(groundings=g) is GT[g]
-                for g in GT]), "FAILED 😔"
-    assert len(model['p2_and_p2a'].state()) == len(GT), "FAILED 😔"
+    model["p2_and_p2a"] = And(model["p2"](x, y), model["p2a"](x, y))
+    model["p2_and_p2a"].upward()
+    assert all(
+        [model["p2_and_p2a"].state(groundings=g) is GT[g] for g in GT]
+    ), "FAILED 😔"
+    assert len(model["p2_and_p2a"].state()) == len(GT), "FAILED 😔"
 
     # 1 variable vs 2 variables
 
     model = Model()  # Reset the model for each new test.
 
-    model['p2'] = Predicate('p2', arity=2)
-    model.add_facts({'p2': {
-        ('s1', 's7'): TRUE,
-        ('s1', 's6'): TRUE,
-        ('s2', 's6'): FALSE,
-        ('s3', 's7'): FALSE,
-        ('s4', 's6'): TRUE}})
+    model["p2"] = Predicate("p2", arity=2)
+    model.add_facts(
+        {
+            "p2": {
+                ("s1", "s7"): TRUE,
+                ("s1", "s6"): TRUE,
+                ("s2", "s6"): FALSE,
+                ("s3", "s7"): FALSE,
+                ("s4", "s6"): TRUE,
+            }
+        }
+    )
 
-    model['p1'] = Predicate('p1')
-    model.add_facts({'p1': {
-        's1': TRUE,
-        's2': TRUE,
-        's3': TRUE,
-        's4': FALSE,
-        's10': FALSE}})
+    model["p1"] = Predicate("p1")
+    model.add_facts(
+        {"p1": {"s1": TRUE, "s2": TRUE, "s3": TRUE, "s4": FALSE, "s10": FALSE}}
+    )
 
-    model['p1_and_p2'] = And(model['p1'](x), model['p2'](x, y))
-    model['p1_and_p2'].upward()
+    model["p1_and_p2"] = And(model["p1"](x), model["p2"](x, y))
+    model["p1_and_p2"].upward()
 
-    GT = dict([
-        (('s1', 's6'), TRUE),
-        (('s3', 's7'), FALSE),
-        (('s2', 's6'), FALSE),
-        (('s1', 's7'), TRUE),
-        (('s4', 's6'), FALSE)])
+    GT = dict(
+        [
+            (("s1", "s6"), TRUE),
+            (("s3", "s7"), FALSE),
+            (("s2", "s6"), FALSE),
+            (("s1", "s7"), TRUE),
+            (("s4", "s6"), FALSE),
+        ]
+    )
 
-    assert all([model['p1_and_p2'].state(groundings=g) is GT[g]
-                for g in GT]), "FAILED 😔"
-    assert len(model['p1_and_p2'].state()) == len(GT), "FAILED 😔"
+    assert all(
+        [model["p1_and_p2"].state(groundings=g) is GT[g] for g in GT]
+    ), "FAILED 😔"
+    assert len(model["p1_and_p2"].state()) == len(GT), "FAILED 😔"
 
     # 2 variable vs 3 variables
-    model['p3'] = Predicate('p3', arity=3)
-    model.add_facts({'p3': {
-        ('s1', 's5', 's3'): TRUE,
-        ('s1', 's4', 's7'): TRUE,
-        ('s1', 's8', 's3'): FALSE,
-        ('s2', 's8', 's6'): TRUE,
-        ('s4', 's6', 's8'): FALSE}})
+    model["p3"] = Predicate("p3", arity=3)
+    model.add_facts(
+        {
+            "p3": {
+                ("s1", "s5", "s3"): TRUE,
+                ("s1", "s4", "s7"): TRUE,
+                ("s1", "s8", "s3"): FALSE,
+                ("s2", "s8", "s6"): TRUE,
+                ("s4", "s6", "s8"): FALSE,
+            }
+        }
+    )
 
-    model['p2_and_p3'] = And(model['p2'](x, y), model['p3'](x, z, y))
-    model['p2_and_p3'].upward()
+    model["p2_and_p3"] = And(model["p2"](x, y), model["p3"](x, z, y))
+    model["p2_and_p3"].upward()
 
-    GT = dict([
-        (('s2', 's6', 's8'), FALSE),
-        (('s1', 's7', 's4'), TRUE)])
-    assert all(model['p2_and_p3'].state(groundings=g) is GT[g]
-               for g in GT), "FAILED 😔"
-    assert len(model['p2_and_p3'].state()) == len(GT), "FAILED 😔"
+    GT = dict([(("s2", "s6", "s8"), FALSE), (("s1", "s7", "s4"), TRUE)])
+    assert all(model["p2_and_p3"].state(groundings=g) is GT[g] for g in GT), "FAILED 😔"
+    assert len(model["p2_and_p3"].state()) == len(GT), "FAILED 😔"
 
     # 1 vs 2 vs 3
-    model['p1_and_p2_and_p3'] = And(model['p1'](x),
-                                    model['p2'](x, y),
-                                    model['p3'](x, z, y))
-    model['p1_and_p2_and_p3'].upward()
+    model["p1_and_p2_and_p3"] = And(
+        model["p1"](x), model["p2"](x, y), model["p3"](x, z, y)
+    )
+    model["p1_and_p2_and_p3"].upward()
 
-    GT = dict([
-        (('s2', 's6', 's8'), FALSE),
-        (('s1', 's7', 's4'), TRUE)])
-    assert all(model['p1_and_p2_and_p3'].state(groundings=g) is GT[g]
-               for g in GT), "FAILED 😔"
-    assert len(model['p1_and_p2_and_p3'].state()) == len(GT), "FAILED 😔"
+    GT = dict([(("s2", "s6", "s8"), FALSE), (("s1", "s7", "s4"), TRUE)])
+    assert all(
+        model["p1_and_p2_and_p3"].state(groundings=g) is GT[g] for g in GT
+    ), "FAILED 😔"
+    assert len(model["p1_and_p2_and_p3"].state()) == len(GT), "FAILED 😔"
 
     # 2 variable vs 2 variable reversed
-    model['p2r'] = Predicate('p2r', arity=2)
-    model.add_facts({'p2r': {
-        ('s6', 's2'): TRUE,
-        ('s7', 's1'): FALSE}})
-    model['p2_and_p2r'] = And(model['p2'](x, y), model['p2r'](y, x))
-    model['p2_and_p2r'].upward()
-    GT = dict([
-        (('s2', 's6'), FALSE),
-        (('s1', 's7'), FALSE)])
-    assert all([model['p2_and_p2r'].state(groundings=g) is GT[g]
-               for g in GT]), "FAILED 😔"
-    assert len(model['p2_and_p2r'].state()) == len(GT), "FAILED 😔"
+    model["p2r"] = Predicate("p2r", arity=2)
+    model.add_facts({"p2r": {("s6", "s2"): TRUE, ("s7", "s1"): FALSE}})
+    model["p2_and_p2r"] = And(model["p2"](x, y), model["p2r"](y, x))
+    model["p2_and_p2r"].upward()
+    GT = dict([(("s2", "s6"), FALSE), (("s1", "s7"), FALSE)])
+    assert all(
+        [model["p2_and_p2r"].state(groundings=g) is GT[g] for g in GT]
+    ), "FAILED 😔"
+    assert len(model["p2_and_p2r"].state()) == len(GT), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_gm_njoin_2.py
+++ b/tests/reasoning/gm/test_gm_njoin_2.py
@@ -4,83 +4,104 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, And, Variable, Predicate, TRUE, FALSE,
-                 UNKNOWN)
+from lnn import Model, And, Variable, Predicate, TRUE, FALSE, UNKNOWN
 
 
 def test():
     model = Model()
-    x, y, z = map(Variable, ('x', 'y', 'z'))
+    x, y, z = map(Variable, ("x", "y", "z"))
 
-    model['p2'] = Predicate('p2', arity=2)
-    model.add_facts({'p2': {
-        ('s1', 's7'): TRUE,
-        ('s1', 's6'): TRUE,
-        ('s2', 's6'): FALSE,
-        ('s3', 's7'): FALSE,
-        ('s4', 's6'): TRUE}})
+    model["p2"] = Predicate("p2", arity=2)
+    model.add_facts(
+        {
+            "p2": {
+                ("s1", "s7"): TRUE,
+                ("s1", "s6"): TRUE,
+                ("s2", "s6"): FALSE,
+                ("s3", "s7"): FALSE,
+                ("s4", "s6"): TRUE,
+            }
+        }
+    )
 
-    model['p1_null'] = Predicate('p1_null')
-    model['p1_and_p2'] = And(model['p1_null'](x), model['p2'](x, y))
-    model['p1_and_p2'].upward()
+    model["p1_null"] = Predicate("p1_null")
+    model["p1_and_p2"] = And(model["p1_null"](x), model["p2"](x, y))
+    model["p1_and_p2"].upward()
 
-    GT = dict([
-        (('s1', 's6'), UNKNOWN),
-        (('s3', 's7'), FALSE),
-        (('s2', 's6'), FALSE),
-        (('s1', 's7'), UNKNOWN),
-        (('s4', 's6'), UNKNOWN)])
+    GT = dict(
+        [
+            (("s1", "s6"), UNKNOWN),
+            (("s3", "s7"), FALSE),
+            (("s2", "s6"), FALSE),
+            (("s1", "s7"), UNKNOWN),
+            (("s4", "s6"), UNKNOWN),
+        ]
+    )
 
-    assert all([model['p1_and_p2'].state(groundings=g) is GT[g]
-                for g in GT]), "FAILED 😔"
-    assert len(model['p1_and_p2'].state()) == len(GT), "FAILED 😔"
+    assert all(
+        [model["p1_and_p2"].state(groundings=g) is GT[g] for g in GT]
+    ), "FAILED 😔"
+    assert len(model["p1_and_p2"].state()) == len(GT), "FAILED 😔"
 
     # 2 variable vs 3 variables
-    model['p2_null'] = Predicate('p2_null', arity=2)
-    model['p3'] = Predicate('p3', arity=3)
-    model.add_facts({'p3': {
-        ('s1', 's5', 's3'): TRUE,
-        ('s1', 's4', 's7'): TRUE,
-        ('s1', 's8', 's3'): FALSE,
-        ('s2', 's8', 's6'): TRUE,
-        ('s4', 's6', 's8'): FALSE}})
+    model["p2_null"] = Predicate("p2_null", arity=2)
+    model["p3"] = Predicate("p3", arity=3)
+    model.add_facts(
+        {
+            "p3": {
+                ("s1", "s5", "s3"): TRUE,
+                ("s1", "s4", "s7"): TRUE,
+                ("s1", "s8", "s3"): FALSE,
+                ("s2", "s8", "s6"): TRUE,
+                ("s4", "s6", "s8"): FALSE,
+            }
+        }
+    )
 
-    model['p2_and_p3'] = And(model['p2_null'](x, y), model['p3'](x, z, y))
-    model['p2_and_p3'].upward()
-    GT = dict([
-        (('s4', 's8', 's6'), FALSE),
-        (('s1', 's3', 's8'), FALSE),
-        (('s1', 's3', 's5'), UNKNOWN),
-        (('s2', 's6', 's8'), UNKNOWN),
-        (('s1', 's7', 's4'), UNKNOWN)])
+    model["p2_and_p3"] = And(model["p2_null"](x, y), model["p3"](x, z, y))
+    model["p2_and_p3"].upward()
+    GT = dict(
+        [
+            (("s4", "s8", "s6"), FALSE),
+            (("s1", "s3", "s8"), FALSE),
+            (("s1", "s3", "s5"), UNKNOWN),
+            (("s2", "s6", "s8"), UNKNOWN),
+            (("s1", "s7", "s4"), UNKNOWN),
+        ]
+    )
 
-    assert all(model['p2_and_p3'].state(groundings=g) is GT[g]
-               for g in GT), "FAILED 😔"
-    assert len(model['p2_and_p3'].state()) == len(GT), "FAILED 😔"
+    assert all(model["p2_and_p3"].state(groundings=g) is GT[g] for g in GT), "FAILED 😔"
+    assert len(model["p2_and_p3"].state()) == len(GT), "FAILED 😔"
 
     # 1 vs 2 vs 3
     model = Model()  # Reset the model for each new test.
-    model['p1_null'] = Predicate('p1_null')
+    model["p1_null"] = Predicate("p1_null")
 
-    model['p2_null'] = Predicate('p2_null', arity=2)
-    model['p3'] = Predicate('p3', arity=3)
-    model.add_facts({'p3': {
-        ('s1', 's5', 's3'): TRUE,
-        ('s1', 's4', 's7'): TRUE,
-        ('s1', 's8', 's3'): FALSE,
-        ('s2', 's8', 's6'): TRUE,
-        ('s4', 's6', 's8'): FALSE}})
+    model["p2_null"] = Predicate("p2_null", arity=2)
+    model["p3"] = Predicate("p3", arity=3)
+    model.add_facts(
+        {
+            "p3": {
+                ("s1", "s5", "s3"): TRUE,
+                ("s1", "s4", "s7"): TRUE,
+                ("s1", "s8", "s3"): FALSE,
+                ("s2", "s8", "s6"): TRUE,
+                ("s4", "s6", "s8"): FALSE,
+            }
+        }
+    )
 
-    model['p1_and_p2_and_p3'] = And(model['p1_null'](x),
-                                    model['p2_null'](x, y),
-                                    model['p3'](x, z, y))
-    model['p1_and_p2_and_p3'].upward()
+    model["p1_and_p2_and_p3"] = And(
+        model["p1_null"](x), model["p2_null"](x, y), model["p3"](x, z, y)
+    )
+    model["p1_and_p2_and_p3"].upward()
 
-    assert all(model['p1_and_p2_and_p3'].state(groundings=g) is GT[g]
-               for g in GT), "FAILED 😔"
-    assert len(model['p1_and_p2_and_p3'].state()) == len(GT), "FAILED 😔"
+    assert all(
+        model["p1_and_p2_and_p3"].state(groundings=g) is GT[g] for g in GT
+    ), "FAILED 😔"
+    assert len(model["p1_and_p2_and_p3"].state()) == len(GT), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_gm_njoin_outer_1.py
+++ b/tests/reasoning/gm/test_gm_njoin_outer_1.py
@@ -10,20 +10,16 @@ from lnn import Model, And, Variable, Predicate, Fact, Join
 def test():
     join = Join.OUTER
     model = Model()
-    x, y, z, a, b = map(Variable, ('x', 'y', 'z', 'a', 'b'))
+    x, y, z, a, b = map(Variable, ("x", "y", "z", "a", "b"))
 
     # TEST 1
 
     # This is the normal 2 var vs 2 var ; should go thru the memory join
-    model['p2'] = Predicate('p2', arity=2)
-    model.add_facts({'p2': {
-        ('x1', 'y1'): Fact.TRUE,
-        ('x2', 'y2'): Fact.TRUE}})
+    model["p2"] = Predicate("p2", arity=2)
+    model.add_facts({"p2": {("x1", "y1"): Fact.TRUE, ("x2", "y2"): Fact.TRUE}})
 
-    model['p2a'] = Predicate('p2a', arity=2)
-    model.add_facts({'p2a': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y3', 'z2'): Fact.TRUE}})
+    model["p2a"] = Predicate("p2a", arity=2)
+    model.add_facts({"p2a": {("y1", "z1"): Fact.TRUE, ("y3", "z2"): Fact.TRUE}})
 
     # print("Predicates before outer Join")
     # model['p2'].print()
@@ -32,17 +28,20 @@ def test():
     # GT_i = dict([
     #    (('x1', 'y1', 'z1'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y1', 'z2'), Fact.UNKNOWN),
-        (('x1', 'y3', 'z2'), Fact.UNKNOWN),
-        (('x2', 'y2', 'z1'), Fact.UNKNOWN),
-        (('x2', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x2', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x2', 'y3', 'z2'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y1", "z2"), Fact.UNKNOWN),
+            (("x1", "y3", "z2"), Fact.UNKNOWN),
+            (("x2", "y2", "z1"), Fact.UNKNOWN),
+            (("x2", "y1", "z1"), Fact.UNKNOWN),
+            (("x2", "y2", "z2"), Fact.UNKNOWN),
+            (("x2", "y3", "z2"), Fact.UNKNOWN),
+        ]
+    )
 
-    model['p2_and_p2a'] = And(model['p2'](x, y), model['p2a'](y, z), join=join)
-    model['p2_and_p2a'].upward()
+    model["p2_and_p2a"] = And(model["p2"](x, y), model["p2a"](y, z), join=join)
+    model["p2_and_p2a"].upward()
 
     # print("Predicates After Join")
     # model['p2'].print()
@@ -52,109 +51,106 @@ def test():
     # for g in GT_o :
     #    print(g, model['p2_and_p2a'].state(groundings=g), GT_o[g])
 
-    assert all([model['p2_and_p2a'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
-    assert len(model['p2_and_p2a'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["p2_and_p2a"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["p2_and_p2a"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 2
     model = Model()
 
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.UNKNOWN),
+            (("x3", "y1", "z1"), Fact.UNKNOWN),
+            (("x3", "y3", "z3"), Fact.UNKNOWN),
+            (("x3", "y2", "z2"), Fact.UNKNOWN),
+        ]
+    )
 
-    model['t2_p3_and_t2_p2'] = And(model['t2_p3'](x, y, z),
-                                   model['t2_p2'](y, z),
-                                   join=join)
-    model['t2_p3_and_t2_p2'].upward()
+    model["t2_p3_and_t2_p2"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), join=join
+    )
+    model["t2_p3_and_t2_p2"].upward()
     # model['t2_p3_and_t2_p2'].print()
 
-    assert all([model['t2_p3_and_t2_p2'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 3
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
-    model['t3_p1'] = Predicate('t3_p1')
-    model.add_facts({'t3_p1': {
-        ('z1'): Fact.TRUE,
-        ('z4'): Fact.TRUE}})
-    model['t2_p3_and_t2_p2_t3_p1'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t3_p1'](z),
-                                         join=join)
-    model['t2_p3_and_t2_p2_t3_p1'].upward()
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
+    model["t3_p1"] = Predicate("t3_p1")
+    model.add_facts({"t3_p1": {("z1"): Fact.TRUE, ("z4"): Fact.TRUE}})
+    model["t2_p3_and_t2_p2_t3_p1"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t3_p1"](z), join=join
+    )
+    model["t2_p3_and_t2_p2_t3_p1"].upward()
     # model['t2_p3_and_t2_p2_t3_p1'].print()
 
     # GT_inner = dict([
     #    (('x1', 'y1', 'z1'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x1', 'y2', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z1'), Fact.UNKNOWN),
-        (('x1', 'y1', 'z4'), Fact.UNKNOWN),
-        (('x1', 'y2', 'z4'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z4'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z4'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z4'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.UNKNOWN),
+            (("x3", "y1", "z1"), Fact.UNKNOWN),
+            (("x3", "y3", "z3"), Fact.UNKNOWN),
+            (("x3", "y2", "z2"), Fact.UNKNOWN),
+            (("x1", "y2", "z1"), Fact.UNKNOWN),
+            (("x3", "y3", "z1"), Fact.UNKNOWN),
+            (("x3", "y2", "z1"), Fact.UNKNOWN),
+            (("x1", "y1", "z4"), Fact.UNKNOWN),
+            (("x1", "y2", "z4"), Fact.UNKNOWN),
+            (("x3", "y1", "z4"), Fact.UNKNOWN),
+            (("x3", "y3", "z4"), Fact.UNKNOWN),
+            (("x3", "y2", "z4"), Fact.UNKNOWN),
+        ]
+    )
 
     # for g in GT_o:
     #    print(g, model['t2_p3_and_t2_p2_t3_p1'].state(groundings=g), GT_o[g])
 
-    assert all([model['t2_p3_and_t2_p2_t3_p1'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t3_p1'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t3_p1"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t3_p1"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 4
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    model['t4_p1'] = Predicate('t4_p1')
-    model.add_facts({'t4_p1': {
-        ('x1'): Fact.TRUE,
-        ('x4'): Fact.TRUE}})
+    model["t4_p1"] = Predicate("t4_p1")
+    model.add_facts({"t4_p1": {("x1"): Fact.TRUE, ("x4"): Fact.TRUE}})
 
-    model['t2_p3_and_t2_p2_t4_p1'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t4_p1'](x),
-                                         join=join)
-    model['t2_p3_and_t2_p2_t4_p1'].upward()
+    model["t2_p3_and_t2_p2_t4_p1"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t4_p1"](x), join=join
+    )
+    model["t2_p3_and_t2_p2_t4_p1"].upward()
     #  model['t2_p3_and_t2_p2_t4_p1'].print()
 
     # for g in GT_o:
@@ -163,67 +159,70 @@ def test():
     # GT_i = dict([
     #    (('x1', 'y1', 'z1'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x1', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x4', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x4', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x4', 'y2', 'z2'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.UNKNOWN),
+            (("x3", "y1", "z1"), Fact.UNKNOWN),
+            (("x3", "y3", "z3"), Fact.UNKNOWN),
+            (("x3", "y2", "z2"), Fact.UNKNOWN),
+            (("x1", "y3", "z3"), Fact.UNKNOWN),
+            (("x4", "y1", "z1"), Fact.UNKNOWN),
+            (("x4", "y3", "z3"), Fact.UNKNOWN),
+            (("x4", "y2", "z2"), Fact.UNKNOWN),
+        ]
+    )
 
-    assert all([model['t2_p3_and_t2_p2_t4_p1'].state(groundings=g)
-                is GT_o[g] for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t4_p1'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t4_p1"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t4_p1"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 5
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    model['t5_p2'] = Predicate('t5_p2', arity=2)
-    model.add_facts({'t5_p2': {
-        ('a1', 'b1'): Fact.TRUE,
-        ('a2', 'b2'): Fact.TRUE}})
+    model["t5_p2"] = Predicate("t5_p2", arity=2)
+    model.add_facts({"t5_p2": {("a1", "b1"): Fact.TRUE, ("a2", "b2"): Fact.TRUE}})
 
-    model['t2_p3_and_t2_p2_t5_p2'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t5_p2'](a, b),
-                                         join=join)
+    model["t2_p3_and_t2_p2_t5_p2"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t5_p2"](a, b), join=join
+    )
 
-    model['t2_p3_and_t2_p2_t5_p2'].upward()
+    model["t2_p3_and_t2_p2_t5_p2"].upward()
     # model['t2_p3_and_t2_p2_t5_p2'].print()
 
     # GT_inner = dict([
     #    (('x1', 'y1', 'z1','a1','b1'), Fact.TRUE),
     #   (('x1', 'y1', 'z1','a2','b2'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1', 'a1', 'b1'), Fact.TRUE),
-        (('x1', 'y2', 'z2', 'a1', 'b1'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1', 'a1', 'b1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3', 'a1', 'b1'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2', 'a1', 'b1'), Fact.UNKNOWN),
-        (('x1', 'y1', 'z1', 'a2', 'b2'), Fact.TRUE),
-        (('x1', 'y2', 'z2', 'a2', 'b2'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1', 'a2', 'b2'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3', 'a2', 'b2'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2', 'a2', 'b2'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1", "a1", "b1"), Fact.TRUE),
+            (("x1", "y2", "z2", "a1", "b1"), Fact.UNKNOWN),
+            (("x3", "y1", "z1", "a1", "b1"), Fact.UNKNOWN),
+            (("x3", "y3", "z3", "a1", "b1"), Fact.UNKNOWN),
+            (("x3", "y2", "z2", "a1", "b1"), Fact.UNKNOWN),
+            (("x1", "y1", "z1", "a2", "b2"), Fact.TRUE),
+            (("x1", "y2", "z2", "a2", "b2"), Fact.UNKNOWN),
+            (("x3", "y1", "z1", "a2", "b2"), Fact.UNKNOWN),
+            (("x3", "y3", "z3", "a2", "b2"), Fact.UNKNOWN),
+            (("x3", "y2", "z2", "a2", "b2"), Fact.UNKNOWN),
+        ]
+    )
 
-    assert all([model['t2_p3_and_t2_p2_t5_p2'].state(groundings=g)
-                is GT_o[g] for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t5_p2'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t5_p2"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t5_p2"].state()) == len(GT_o), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_gm_njoin_outer_2.py
+++ b/tests/reasoning/gm/test_gm_njoin_outer_2.py
@@ -10,20 +10,16 @@ from lnn import Model, And, Variable, Predicate, Fact, Join
 def test():
     join = Join.OUTER
     model = Model()
-    x, y, z, a, b = map(Variable, ('x', 'y', 'z', 'a', 'b'))
+    x, y, z, a, b = map(Variable, ("x", "y", "z", "a", "b"))
 
     # TEST 1
 
     # This is the normal 2 var vs 2 var ; should go thru the memory join
-    model['p2'] = Predicate('p2', arity=2)
-    model.add_facts({'p2': {
-        ('x1', 'y1'): Fact.TRUE,
-        ('x2', 'y2'): Fact.TRUE}})
+    model["p2"] = Predicate("p2", arity=2)
+    model.add_facts({"p2": {("x1", "y1"): Fact.TRUE, ("x2", "y2"): Fact.TRUE}})
 
-    model['p2a'] = Predicate('p2a', arity=2)
-    model.add_facts({'p2a': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y3', 'z2'): Fact.TRUE}})
+    model["p2a"] = Predicate("p2a", arity=2)
+    model.add_facts({"p2a": {("y1", "z1"): Fact.TRUE, ("y3", "z2"): Fact.TRUE}})
 
     # print("Predicates before outer Join")
     # model['p2'].print()
@@ -32,17 +28,20 @@ def test():
     # GT_i = dict([
     #    (('x1', 'y1', 'z1'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y1', 'z2'), Fact.UNKNOWN),
-        (('x1', 'y3', 'z2'), Fact.UNKNOWN),
-        (('x2', 'y2', 'z1'), Fact.UNKNOWN),
-        (('x2', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x2', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x2', 'y3', 'z2'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y1", "z2"), Fact.UNKNOWN),
+            (("x1", "y3", "z2"), Fact.UNKNOWN),
+            (("x2", "y2", "z1"), Fact.UNKNOWN),
+            (("x2", "y1", "z1"), Fact.UNKNOWN),
+            (("x2", "y2", "z2"), Fact.UNKNOWN),
+            (("x2", "y3", "z2"), Fact.UNKNOWN),
+        ]
+    )
 
-    model['p2_and_p2a'] = And(model['p2'](x, y), model['p2a'](y, z), join=join)
-    model['p2_and_p2a'].upward()
+    model["p2_and_p2a"] = And(model["p2"](x, y), model["p2a"](y, z), join=join)
+    model["p2_and_p2a"].upward()
 
     # print("Predicates After Join")
     # model['p2'].print()
@@ -52,35 +51,39 @@ def test():
     # for g in GT_o :
     #    print(g, model['p2_and_p2a'].state(groundings=g), GT_o[g])
 
-    assert all([model['p2_and_p2a'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
-    assert len(model['p2_and_p2a'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["p2_and_p2a"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["p2_and_p2a"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 2
     model = Model()
 
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
     # model.add_facts({'t2_p2': {
     #    ('y1', 'z1'): Fact.TRUE,
     #    ('y2', 'z2'): Fact.TRUE}})
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.UNKNOWN),
+            (("x3", "y1", "z1"), Fact.UNKNOWN),
+            (("x3", "y3", "z3"), Fact.UNKNOWN),
+            (("x3", "y2", "z2"), Fact.UNKNOWN),
+        ]
+    )
 
-    model['t2_p3_and_t2_p2'] = And(model['t2_p3'](x, y, z),
-                                   model['t2_p2'](y, z),
-                                   join=join)
-    model['t2_p3_and_t2_p2'].upward()
-    model['t2_p3_and_t2_p2'].print()
+    model["t2_p3_and_t2_p2"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), join=join
+    )
+    model["t2_p3_and_t2_p2"].upward()
+    model["t2_p3_and_t2_p2"].print()
 
     # assert all([model['t2_p3_and_t2_p2'].state(groundings=g) is GT_o[g]
     #            for g in GT_o]), "FAILED 😔"
@@ -88,43 +91,45 @@ def test():
 
     # TEST 3
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
     # model.add_facts({'t2_p2': {
     #    ('y1', 'z1'): Fact.TRUE,
     #    ('y2', 'z2'): Fact.TRUE}})
-    model['t3_p1'] = Predicate('t3_p1')
+    model["t3_p1"] = Predicate("t3_p1")
     # model.add_facts({'t3_p1': {
     #    ('z1'): Fact.TRUE,
     #    ('z4'): Fact.TRUE}})
-    model['t2_p3_and_t2_p2_t3_p1'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t3_p1'](z),
-                                         join=join)
-    model['t2_p3_and_t2_p2_t3_p1'].upward()
-    model['t2_p3_and_t2_p2_t3_p1'].print()
+    model["t2_p3_and_t2_p2_t3_p1"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t3_p1"](z), join=join
+    )
+    model["t2_p3_and_t2_p2_t3_p1"].upward()
+    model["t2_p3_and_t2_p2_t3_p1"].print()
 
     # GT_inner = dict([
     #    (('x1', 'y1', 'z1'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x1', 'y2', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z1'), Fact.UNKNOWN),
-        (('x1', 'y1', 'z4'), Fact.UNKNOWN),
-        (('x1', 'y2', 'z4'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z4'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z4'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z4'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.UNKNOWN),
+            (("x3", "y1", "z1"), Fact.UNKNOWN),
+            (("x3", "y3", "z3"), Fact.UNKNOWN),
+            (("x3", "y2", "z2"), Fact.UNKNOWN),
+            (("x1", "y2", "z1"), Fact.UNKNOWN),
+            (("x3", "y3", "z1"), Fact.UNKNOWN),
+            (("x3", "y2", "z1"), Fact.UNKNOWN),
+            (("x1", "y1", "z4"), Fact.UNKNOWN),
+            (("x1", "y2", "z4"), Fact.UNKNOWN),
+            (("x3", "y1", "z4"), Fact.UNKNOWN),
+            (("x3", "y3", "z4"), Fact.UNKNOWN),
+            (("x3", "y2", "z4"), Fact.UNKNOWN),
+        ]
+    )
 
     # for g in GT_o:
     #    print(g, model['t2_p3_and_t2_p2_t3_p1'].state(groundings=g), GT_o[g])
@@ -136,27 +141,22 @@ def test():
 
     # TEST 4
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
     # model.add_facts({'t2_p3': {
     #    ('x1', 'y1', 'z1'): Fact.TRUE,
     #    ('x3', 'y3', 'z3'): Fact.TRUE}})
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    model['t4_p1'] = Predicate('t4_p1')
-    model.add_facts({'t4_p1': {
-        ('x1'): Fact.TRUE,
-        ('x4'): Fact.TRUE}})
+    model["t4_p1"] = Predicate("t4_p1")
+    model.add_facts({"t4_p1": {("x1"): Fact.TRUE, ("x4"): Fact.TRUE}})
 
-    model['t2_p3_and_t2_p2_t4_p1'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t4_p1'](x),
-                                         join=join)
-    model['t2_p3_and_t2_p2_t4_p1'].upward()
-    model['t2_p3_and_t2_p2_t4_p1'].print()
+    model["t2_p3_and_t2_p2_t4_p1"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t4_p1"](x), join=join
+    )
+    model["t2_p3_and_t2_p2_t4_p1"].upward()
+    model["t2_p3_and_t2_p2_t4_p1"].print()
 
     # for g in GT_o:
     #    print(g, model['t2_p3_and_t2_p2_t4_p1'].state(groundings=g), GT_o[g])
@@ -164,16 +164,19 @@ def test():
     # GT_i = dict([
     #    (('x1', 'y1', 'z1'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2'), Fact.UNKNOWN),
-        (('x1', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x4', 'y1', 'z1'), Fact.UNKNOWN),
-        (('x4', 'y3', 'z3'), Fact.UNKNOWN),
-        (('x4', 'y2', 'z2'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.UNKNOWN),
+            (("x3", "y1", "z1"), Fact.UNKNOWN),
+            (("x3", "y3", "z3"), Fact.UNKNOWN),
+            (("x3", "y2", "z2"), Fact.UNKNOWN),
+            (("x1", "y3", "z3"), Fact.UNKNOWN),
+            (("x4", "y1", "z1"), Fact.UNKNOWN),
+            (("x4", "y3", "z3"), Fact.UNKNOWN),
+            (("x4", "y2", "z2"), Fact.UNKNOWN),
+        ]
+    )
 
     # assert all([model['t2_p3_and_t2_p2_t4_p1'].state(groundings=g)
     #            is GT_o[g] for g in GT_o]), "FAILED 😔"
@@ -182,50 +185,49 @@ def test():
 
     # TEST 5
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    model['t5_p2'] = Predicate('t5_p2', arity=2)
-    model.add_facts({'t5_p2': {
-        ('a1', 'b1'): Fact.TRUE,
-        ('a2', 'b2'): Fact.TRUE}})
+    model["t5_p2"] = Predicate("t5_p2", arity=2)
+    model.add_facts({"t5_p2": {("a1", "b1"): Fact.TRUE, ("a2", "b2"): Fact.TRUE}})
 
-    model['t2_p3_and_t2_p2_t5_p2'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t5_p2'](a, b),
-                                         join=join)
+    model["t2_p3_and_t2_p2_t5_p2"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t5_p2"](a, b), join=join
+    )
 
-    model['t2_p3_and_t2_p2_t5_p2'].upward()
+    model["t2_p3_and_t2_p2_t5_p2"].upward()
     # model['t2_p3_and_t2_p2_t5_p2'].print()
 
     # GT_inner = dict([
     #    (('x1', 'y1', 'z1','a1','b1'), Fact.TRUE),
     #   (('x1', 'y1', 'z1','a2','b2'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1', 'a1', 'b1'), Fact.TRUE),
-        (('x1', 'y2', 'z2', 'a1', 'b1'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1', 'a1', 'b1'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3', 'a1', 'b1'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2', 'a1', 'b1'), Fact.UNKNOWN),
-        (('x1', 'y1', 'z1', 'a2', 'b2'), Fact.TRUE),
-        (('x1', 'y2', 'z2', 'a2', 'b2'), Fact.UNKNOWN),
-        (('x3', 'y1', 'z1', 'a2', 'b2'), Fact.UNKNOWN),
-        (('x3', 'y3', 'z3', 'a2', 'b2'), Fact.UNKNOWN),
-        (('x3', 'y2', 'z2', 'a2', 'b2'), Fact.UNKNOWN)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1", "a1", "b1"), Fact.TRUE),
+            (("x1", "y2", "z2", "a1", "b1"), Fact.UNKNOWN),
+            (("x3", "y1", "z1", "a1", "b1"), Fact.UNKNOWN),
+            (("x3", "y3", "z3", "a1", "b1"), Fact.UNKNOWN),
+            (("x3", "y2", "z2", "a1", "b1"), Fact.UNKNOWN),
+            (("x1", "y1", "z1", "a2", "b2"), Fact.TRUE),
+            (("x1", "y2", "z2", "a2", "b2"), Fact.UNKNOWN),
+            (("x3", "y1", "z1", "a2", "b2"), Fact.UNKNOWN),
+            (("x3", "y3", "z3", "a2", "b2"), Fact.UNKNOWN),
+            (("x3", "y2", "z2", "a2", "b2"), Fact.UNKNOWN),
+        ]
+    )
 
-    assert all([model['t2_p3_and_t2_p2_t5_p2'].state(groundings=g)
-                is GT_o[g] for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t5_p2'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t5_p2"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t5_p2"].state()) == len(GT_o), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_gm_njoin_outer_pruned_1.py
+++ b/tests/reasoning/gm/test_gm_njoin_outer_pruned_1.py
@@ -10,245 +10,243 @@ from lnn import Model, And, Variable, Predicate, Fact, Join
 def test():
     join = Join.OUTER_PRUNED
     model = Model()
-    x, y, z, a, b = map(Variable, ('x', 'y', 'z', 'a', 'b'))
+    x, y, z, a, b = map(Variable, ("x", "y", "z", "a", "b"))
 
     # TEST 1
 
     # This is the normal 2 var vs 2 var ; should go thru the memory join
-    model['p2'] = Predicate('p2', arity=2)
-    model.add_facts({'p2': {
-        ('x1', 'y1'): Fact.TRUE,
-        ('x2', 'y2'): Fact.TRUE}})
+    model["p2"] = Predicate("p2", arity=2)
+    model.add_facts({"p2": {("x1", "y1"): Fact.TRUE, ("x2", "y2"): Fact.TRUE}})
 
-    model['p2a'] = Predicate('p2a', arity=2)
-    model.add_facts({'p2a': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y3', 'z2'): Fact.TRUE}})
+    model["p2a"] = Predicate("p2a", arity=2)
+    model.add_facts({"p2a": {("y1", "z1"): Fact.TRUE, ("y3", "z2"): Fact.TRUE}})
 
-    v1_before = model['p2'].state()
-    v2_before = model['p2a'].state()
+    v1_before = model["p2"].state()
+    v2_before = model["p2a"].state()
 
     # GT_i = dict([
     #    (('x1', 'y1', 'z1'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y1', 'z2'), Fact.TRUE),
-        (('x1', 'y3', 'z2'), Fact.TRUE),
-        (('x2', 'y2', 'z1'), Fact.TRUE),
-        (('x2', 'y1', 'z1'), Fact.TRUE),
-        (('x2', 'y2', 'z2'), Fact.TRUE),
-        (('x2', 'y3', 'z2'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y1", "z2"), Fact.TRUE),
+            (("x1", "y3", "z2"), Fact.TRUE),
+            (("x2", "y2", "z1"), Fact.TRUE),
+            (("x2", "y1", "z1"), Fact.TRUE),
+            (("x2", "y2", "z2"), Fact.TRUE),
+            (("x2", "y3", "z2"), Fact.TRUE),
+        ]
+    )
 
-    model['p2_and_p2a'] = And(model['p2'](x, y), model['p2a'](y, z),
-                              join=join)
-    model['p2_and_p2a'].upward()
+    model["p2_and_p2a"] = And(model["p2"](x, y), model["p2a"](y, z), join=join)
+    model["p2_and_p2a"].upward()
 
-    v1_after = model['p2'].state()
-    v2_after = model['p2a'].state()
+    v1_after = model["p2"].state()
+    v2_after = model["p2a"].state()
 
-    assert (v1_after == v1_before),  "FAILED 😔"
-    assert (v2_after == v2_before),  "FAILED 😔"
-    assert all([model['p2_and_p2a'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
-    assert len(model['p2_and_p2a'].state()) == len(GT_o), "FAILED 😔"
+    assert v1_after == v1_before, "FAILED 😔"
+    assert v2_after == v2_before, "FAILED 😔"
+    assert all(
+        [model["p2_and_p2a"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["p2_and_p2a"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 2
     model = Model()
 
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.TRUE),
-        (('x3', 'y1', 'z1'), Fact.TRUE),
-        (('x3', 'y3', 'z3'), Fact.TRUE),
-        (('x3', 'y2', 'z2'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.TRUE),
+            (("x3", "y1", "z1"), Fact.TRUE),
+            (("x3", "y3", "z3"), Fact.TRUE),
+            (("x3", "y2", "z2"), Fact.TRUE),
+        ]
+    )
 
-    model['t2_p3_and_t2_p2'] = And(model['t2_p3'](x, y, z),
-                                   model['t2_p2'](y, z),
-                                   join=join)
+    model["t2_p3_and_t2_p2"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), join=join
+    )
 
-    v1_before = model['t2_p3'].state()
-    v2_before = model['t2_p2'].state()
+    v1_before = model["t2_p3"].state()
+    v2_before = model["t2_p2"].state()
 
-    model['t2_p3_and_t2_p2'].upward()
+    model["t2_p3_and_t2_p2"].upward()
 
-    v1_after = model['t2_p3'].state()
-    v2_after = model['t2_p2'].state()
+    v1_after = model["t2_p3"].state()
+    v2_after = model["t2_p2"].state()
 
-    assert (v1_after == v1_before),  "FAILED 😔"
-    assert (v2_after == v2_before),  "FAILED 😔"
+    assert v1_after == v1_before, "FAILED 😔"
+    assert v2_after == v2_before, "FAILED 😔"
 
-    assert all([model['t2_p3_and_t2_p2'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 3
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
-    model['t3_p1'] = Predicate('t3_p1')
-    model.add_facts({'t3_p1': {
-        ('z1'): Fact.TRUE,
-        ('z4'): Fact.TRUE}})
-    model['t2_p3_and_t2_p2_t3_p1'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t3_p1'](z),
-                                         join=join)
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
+    model["t3_p1"] = Predicate("t3_p1")
+    model.add_facts({"t3_p1": {("z1"): Fact.TRUE, ("z4"): Fact.TRUE}})
+    model["t2_p3_and_t2_p2_t3_p1"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t3_p1"](z), join=join
+    )
 
-    v1_before = model['t2_p3'].state()
-    v2_before = model['t2_p2'].state()
-    v3_before = model['t3_p1'].state()
+    v1_before = model["t2_p3"].state()
+    v2_before = model["t2_p2"].state()
+    v3_before = model["t3_p1"].state()
 
-    model['t2_p3_and_t2_p2_t3_p1'].upward()
+    model["t2_p3_and_t2_p2_t3_p1"].upward()
 
-    v1_after = model['t2_p3'].state()
-    v2_after = model['t2_p2'].state()
-    v3_after = model['t3_p1'].state()
+    v1_after = model["t2_p3"].state()
+    v2_after = model["t2_p2"].state()
+    v3_after = model["t3_p1"].state()
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.TRUE),
-        (('x3', 'y1', 'z1'), Fact.TRUE),
-        (('x3', 'y3', 'z3'), Fact.TRUE),
-        (('x3', 'y2', 'z2'), Fact.TRUE),
-        (('x1', 'y2', 'z1'), Fact.TRUE),
-        (('x3', 'y3', 'z1'), Fact.TRUE),
-        (('x3', 'y2', 'z1'), Fact.TRUE),
-        (('x1', 'y1', 'z4'), Fact.TRUE),
-        (('x1', 'y2', 'z4'), Fact.TRUE),
-        (('x3', 'y1', 'z4'), Fact.TRUE),
-        (('x3', 'y3', 'z4'), Fact.TRUE),
-        (('x3', 'y2', 'z4'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.TRUE),
+            (("x3", "y1", "z1"), Fact.TRUE),
+            (("x3", "y3", "z3"), Fact.TRUE),
+            (("x3", "y2", "z2"), Fact.TRUE),
+            (("x1", "y2", "z1"), Fact.TRUE),
+            (("x3", "y3", "z1"), Fact.TRUE),
+            (("x3", "y2", "z1"), Fact.TRUE),
+            (("x1", "y1", "z4"), Fact.TRUE),
+            (("x1", "y2", "z4"), Fact.TRUE),
+            (("x3", "y1", "z4"), Fact.TRUE),
+            (("x3", "y3", "z4"), Fact.TRUE),
+            (("x3", "y2", "z4"), Fact.TRUE),
+        ]
+    )
 
-    assert (v1_after == v1_before),  "FAILED 😔"
-    assert (v2_after == v2_before),  "FAILED 😔"
-    assert (v3_after == v3_before),  "FAILED 😔"
+    assert v1_after == v1_before, "FAILED 😔"
+    assert v2_after == v2_before, "FAILED 😔"
+    assert v3_after == v3_before, "FAILED 😔"
 
-    assert all([model['t2_p3_and_t2_p2_t3_p1'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t3_p1'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t3_p1"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t3_p1"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 4
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    model['t4_p1'] = Predicate('t4_p1')
-    model.add_facts({'t4_p1': {
-        ('x1'): Fact.TRUE,
-        ('x4'): Fact.TRUE}})
+    model["t4_p1"] = Predicate("t4_p1")
+    model.add_facts({"t4_p1": {("x1"): Fact.TRUE, ("x4"): Fact.TRUE}})
 
-    model['t2_p3_and_t2_p2_t4_p1'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t4_p1'](x),
-                                         join=join)
+    model["t2_p3_and_t2_p2_t4_p1"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t4_p1"](x), join=join
+    )
 
-    v1_before = model['t2_p3'].state()
-    v2_before = model['t2_p2'].state()
-    v3_before = model['t4_p1'].state()
+    v1_before = model["t2_p3"].state()
+    v2_before = model["t2_p2"].state()
+    v3_before = model["t4_p1"].state()
 
-    model['t2_p3_and_t2_p2_t4_p1'].upward()
+    model["t2_p3_and_t2_p2_t4_p1"].upward()
 
-    v1_after = model['t2_p3'].state()
-    v2_after = model['t2_p2'].state()
-    v3_after = model['t4_p1'].state()
+    v1_after = model["t2_p3"].state()
+    v2_after = model["t2_p2"].state()
+    v3_after = model["t4_p1"].state()
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.TRUE),
-        (('x3', 'y1', 'z1'), Fact.TRUE),
-        (('x3', 'y3', 'z3'), Fact.TRUE),
-        (('x3', 'y2', 'z2'), Fact.TRUE),
-        (('x1', 'y3', 'z3'), Fact.TRUE),
-        (('x4', 'y1', 'z1'), Fact.TRUE),
-        (('x4', 'y3', 'z3'), Fact.TRUE),
-        (('x4', 'y2', 'z2'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.TRUE),
+            (("x3", "y1", "z1"), Fact.TRUE),
+            (("x3", "y3", "z3"), Fact.TRUE),
+            (("x3", "y2", "z2"), Fact.TRUE),
+            (("x1", "y3", "z3"), Fact.TRUE),
+            (("x4", "y1", "z1"), Fact.TRUE),
+            (("x4", "y3", "z3"), Fact.TRUE),
+            (("x4", "y2", "z2"), Fact.TRUE),
+        ]
+    )
 
-    assert (v1_after == v1_before),  "FAILED 😔"
-    assert (v2_after == v2_before),  "FAILED 😔"
-    assert (v3_after == v3_before),  "FAILED 😔"
+    assert v1_after == v1_before, "FAILED 😔"
+    assert v2_after == v2_before, "FAILED 😔"
+    assert v3_after == v3_before, "FAILED 😔"
 
-    assert all([model['t2_p3_and_t2_p2_t4_p1'].state(groundings=g)
-                is GT_o[g] for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t4_p1'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t4_p1"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t4_p1"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 5
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    model['t5_p2'] = Predicate('t5_p2', arity=2)
-    model.add_facts({'t5_p2': {
-        ('a1', 'b1'): Fact.TRUE,
-        ('a2', 'b2'): Fact.TRUE}})
+    model["t5_p2"] = Predicate("t5_p2", arity=2)
+    model.add_facts({"t5_p2": {("a1", "b1"): Fact.TRUE, ("a2", "b2"): Fact.TRUE}})
 
-    model['t2_p3_and_t2_p2_t5_p2'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t5_p2'](a, b),
-                                         join=join)
+    model["t2_p3_and_t2_p2_t5_p2"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t5_p2"](a, b), join=join
+    )
 
-    v1_before = model['t2_p3'].state()
-    v2_before = model['t2_p2'].state()
-    v3_before = model['t5_p2'].state()
+    v1_before = model["t2_p3"].state()
+    v2_before = model["t2_p2"].state()
+    v3_before = model["t5_p2"].state()
 
-    model['t2_p3_and_t2_p2_t5_p2'].upward()
+    model["t2_p3_and_t2_p2_t5_p2"].upward()
 
-    v1_after = model['t2_p3'].state()
-    v2_after = model['t2_p2'].state()
-    v3_after = model['t5_p2'].state()
+    v1_after = model["t2_p3"].state()
+    v2_after = model["t2_p2"].state()
+    v3_after = model["t5_p2"].state()
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1', 'a1', 'b1'), Fact.TRUE),
-        (('x1', 'y2', 'z2', 'a1', 'b1'), Fact.TRUE),
-        (('x3', 'y1', 'z1', 'a1', 'b1'), Fact.TRUE),
-        (('x3', 'y3', 'z3', 'a1', 'b1'), Fact.TRUE),
-        (('x3', 'y2', 'z2', 'a1', 'b1'), Fact.TRUE),
-        (('x1', 'y1', 'z1', 'a2', 'b2'), Fact.TRUE),
-        (('x1', 'y2', 'z2', 'a2', 'b2'), Fact.TRUE),
-        (('x3', 'y1', 'z1', 'a2', 'b2'), Fact.TRUE),
-        (('x3', 'y3', 'z3', 'a2', 'b2'), Fact.TRUE),
-        (('x3', 'y2', 'z2', 'a2', 'b2'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1", "a1", "b1"), Fact.TRUE),
+            (("x1", "y2", "z2", "a1", "b1"), Fact.TRUE),
+            (("x3", "y1", "z1", "a1", "b1"), Fact.TRUE),
+            (("x3", "y3", "z3", "a1", "b1"), Fact.TRUE),
+            (("x3", "y2", "z2", "a1", "b1"), Fact.TRUE),
+            (("x1", "y1", "z1", "a2", "b2"), Fact.TRUE),
+            (("x1", "y2", "z2", "a2", "b2"), Fact.TRUE),
+            (("x3", "y1", "z1", "a2", "b2"), Fact.TRUE),
+            (("x3", "y3", "z3", "a2", "b2"), Fact.TRUE),
+            (("x3", "y2", "z2", "a2", "b2"), Fact.TRUE),
+        ]
+    )
 
-    assert (v1_after == v1_before),  "FAILED 😔"
-    assert (v2_after == v2_before),  "FAILED 😔"
-    assert (v3_after == v3_before),  "FAILED 😔"
+    assert v1_after == v1_before, "FAILED 😔"
+    assert v2_after == v2_before, "FAILED 😔"
+    assert v3_after == v3_before, "FAILED 😔"
 
-    assert all([model['t2_p3_and_t2_p2_t5_p2'].state(groundings=g)
-                is GT_o[g] for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t5_p2'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t5_p2"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t5_p2"].state()) == len(GT_o), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_gm_njoin_outer_pruned_2.py
+++ b/tests/reasoning/gm/test_gm_njoin_outer_pruned_2.py
@@ -10,43 +10,43 @@ from lnn import Model, And, Variable, Predicate, Fact, Join
 def test():
     join = Join.OUTER_PRUNED
     model = Model()
-    x, y, z, a, b = map(Variable, ('x', 'y', 'z', 'a', 'b'))
+    x, y, z, a, b = map(Variable, ("x", "y", "z", "a", "b"))
 
     # TEST 1
 
     # This is the normal 2 var vs 2 var ; should go thru the memory join
-    model['p2'] = Predicate('p2', arity=2)
+    model["p2"] = Predicate("p2", arity=2)
     # model.add_facts({'p2': {
     #    ('x1', 'y1'): Fact.TRUE,
     #    ('x2', 'y2'): Fact.TRUE}})
 
-    model['p2a'] = Predicate('p2a', arity=2)
-    model.add_facts({'p2a': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y3', 'z2'): Fact.TRUE}})
+    model["p2a"] = Predicate("p2a", arity=2)
+    model.add_facts({"p2a": {("y1", "z1"): Fact.TRUE, ("y3", "z2"): Fact.TRUE}})
 
-    v1_before = model['p2'].state()
-    v2_before = model['p2a'].state()
+    v1_before = model["p2"].state()
+    v2_before = model["p2a"].state()
 
     # GT_i = dict([
     #    (('x1', 'y1', 'z1'), Fact.TRUE)])
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y1', 'z2'), Fact.TRUE),
-        (('x1', 'y3', 'z2'), Fact.TRUE),
-        (('x2', 'y2', 'z1'), Fact.TRUE),
-        (('x2', 'y1', 'z1'), Fact.TRUE),
-        (('x2', 'y2', 'z2'), Fact.TRUE),
-        (('x2', 'y3', 'z2'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y1", "z2"), Fact.TRUE),
+            (("x1", "y3", "z2"), Fact.TRUE),
+            (("x2", "y2", "z1"), Fact.TRUE),
+            (("x2", "y1", "z1"), Fact.TRUE),
+            (("x2", "y2", "z2"), Fact.TRUE),
+            (("x2", "y3", "z2"), Fact.TRUE),
+        ]
+    )
 
-    model['p2_and_p2a'] = And(model['p2'](x, y), model['p2a'](y, z),
-                              join=join)
+    model["p2_and_p2a"] = And(model["p2"](x, y), model["p2a"](y, z), join=join)
     # model['p2_and_p2a'].upward()
     # model['p2_and_p2a'].print()
 
-    v1_after = model['p2'].state()
-    v2_after = model['p2a'].state()
+    v1_after = model["p2"].state()
+    v2_after = model["p2a"].state()
 
     # assert (v1_after == v1_before),  "FAILED 😔"
     # assert (v2_after == v2_before),  "FAILED 😔"
@@ -57,35 +57,38 @@ def test():
     # TEST 2
     model = Model()
 
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
     # model.add_facts({'t2_p2': {
     #    ('y1', 'z1'): Fact.TRUE,
     #    ('y2', 'z2'): Fact.TRUE}})
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.TRUE),
-        (('x3', 'y1', 'z1'), Fact.TRUE),
-        (('x3', 'y3', 'z3'), Fact.TRUE),
-        (('x3', 'y2', 'z2'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.TRUE),
+            (("x3", "y1", "z1"), Fact.TRUE),
+            (("x3", "y3", "z3"), Fact.TRUE),
+            (("x3", "y2", "z2"), Fact.TRUE),
+        ]
+    )
 
-    model['t2_p3_and_t2_p2'] = And(model['t2_p3'](x, y, z),
-                                   model['t2_p2'](y, z),
-                                   join=join)
+    model["t2_p3_and_t2_p2"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), join=join
+    )
 
-    v1_before = model['t2_p3'].state()
-    v2_before = model['t2_p2'].state()
+    v1_before = model["t2_p3"].state()
+    v2_before = model["t2_p2"].state()
 
-    model['t2_p3_and_t2_p2'].upward()
-    model['t2_p3_and_t2_p2'].print()
+    model["t2_p3_and_t2_p2"].upward()
+    model["t2_p3_and_t2_p2"].print()
 
-    v1_after = model['t2_p3'].state()
-    v2_after = model['t2_p2'].state()
+    v1_after = model["t2_p3"].state()
+    v2_after = model["t2_p2"].state()
 
     # assert (v1_after == v1_before),  "FAILED 😔"
     # assert (v2_after == v2_before),  "FAILED 😔"
@@ -96,161 +99,158 @@ def test():
 
     # TEST 3
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
-    model['t3_p1'] = Predicate('t3_p1')
-    model.add_facts({'t3_p1': {
-        ('z1'): Fact.TRUE,
-        ('z4'): Fact.TRUE}})
-    model['t2_p3_and_t2_p2_t3_p1'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t3_p1'](z),
-                                         join=join)
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
+    model["t3_p1"] = Predicate("t3_p1")
+    model.add_facts({"t3_p1": {("z1"): Fact.TRUE, ("z4"): Fact.TRUE}})
+    model["t2_p3_and_t2_p2_t3_p1"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t3_p1"](z), join=join
+    )
 
-    v1_before = model['t2_p3'].state()
-    v2_before = model['t2_p2'].state()
-    v3_before = model['t3_p1'].state()
+    v1_before = model["t2_p3"].state()
+    v2_before = model["t2_p2"].state()
+    v3_before = model["t3_p1"].state()
 
-    model['t2_p3_and_t2_p2_t3_p1'].upward()
+    model["t2_p3_and_t2_p2_t3_p1"].upward()
 
-    v1_after = model['t2_p3'].state()
-    v2_after = model['t2_p2'].state()
-    v3_after = model['t3_p1'].state()
+    v1_after = model["t2_p3"].state()
+    v2_after = model["t2_p2"].state()
+    v3_after = model["t3_p1"].state()
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.TRUE),
-        (('x3', 'y1', 'z1'), Fact.TRUE),
-        (('x3', 'y3', 'z3'), Fact.TRUE),
-        (('x3', 'y2', 'z2'), Fact.TRUE),
-        (('x1', 'y2', 'z1'), Fact.TRUE),
-        (('x3', 'y3', 'z1'), Fact.TRUE),
-        (('x3', 'y2', 'z1'), Fact.TRUE),
-        (('x1', 'y1', 'z4'), Fact.TRUE),
-        (('x1', 'y2', 'z4'), Fact.TRUE),
-        (('x3', 'y1', 'z4'), Fact.TRUE),
-        (('x3', 'y3', 'z4'), Fact.TRUE),
-        (('x3', 'y2', 'z4'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.TRUE),
+            (("x3", "y1", "z1"), Fact.TRUE),
+            (("x3", "y3", "z3"), Fact.TRUE),
+            (("x3", "y2", "z2"), Fact.TRUE),
+            (("x1", "y2", "z1"), Fact.TRUE),
+            (("x3", "y3", "z1"), Fact.TRUE),
+            (("x3", "y2", "z1"), Fact.TRUE),
+            (("x1", "y1", "z4"), Fact.TRUE),
+            (("x1", "y2", "z4"), Fact.TRUE),
+            (("x3", "y1", "z4"), Fact.TRUE),
+            (("x3", "y3", "z4"), Fact.TRUE),
+            (("x3", "y2", "z4"), Fact.TRUE),
+        ]
+    )
 
-    assert (v1_after == v1_before),  "FAILED 😔"
-    assert (v2_after == v2_before),  "FAILED 😔"
-    assert (v3_after == v3_before),  "FAILED 😔"
+    assert v1_after == v1_before, "FAILED 😔"
+    assert v2_after == v2_before, "FAILED 😔"
+    assert v3_after == v3_before, "FAILED 😔"
 
-    assert all([model['t2_p3_and_t2_p2_t3_p1'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t3_p1'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t3_p1"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t3_p1"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 4
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    model['t4_p1'] = Predicate('t4_p1')
-    model.add_facts({'t4_p1': {
-        ('x1'): Fact.TRUE,
-        ('x4'): Fact.TRUE}})
+    model["t4_p1"] = Predicate("t4_p1")
+    model.add_facts({"t4_p1": {("x1"): Fact.TRUE, ("x4"): Fact.TRUE}})
 
-    model['t2_p3_and_t2_p2_t4_p1'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t4_p1'](x),
-                                         join=join)
+    model["t2_p3_and_t2_p2_t4_p1"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t4_p1"](x), join=join
+    )
 
-    v1_before = model['t2_p3'].state()
-    v2_before = model['t2_p2'].state()
-    v3_before = model['t4_p1'].state()
+    v1_before = model["t2_p3"].state()
+    v2_before = model["t2_p2"].state()
+    v3_before = model["t4_p1"].state()
 
-    model['t2_p3_and_t2_p2_t4_p1'].upward()
+    model["t2_p3_and_t2_p2_t4_p1"].upward()
 
-    v1_after = model['t2_p3'].state()
-    v2_after = model['t2_p2'].state()
-    v3_after = model['t4_p1'].state()
+    v1_after = model["t2_p3"].state()
+    v2_after = model["t2_p2"].state()
+    v3_after = model["t4_p1"].state()
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1'), Fact.TRUE),
-        (('x1', 'y2', 'z2'), Fact.TRUE),
-        (('x3', 'y1', 'z1'), Fact.TRUE),
-        (('x3', 'y3', 'z3'), Fact.TRUE),
-        (('x3', 'y2', 'z2'), Fact.TRUE),
-        (('x1', 'y3', 'z3'), Fact.TRUE),
-        (('x4', 'y1', 'z1'), Fact.TRUE),
-        (('x4', 'y3', 'z3'), Fact.TRUE),
-        (('x4', 'y2', 'z2'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1"), Fact.TRUE),
+            (("x1", "y2", "z2"), Fact.TRUE),
+            (("x3", "y1", "z1"), Fact.TRUE),
+            (("x3", "y3", "z3"), Fact.TRUE),
+            (("x3", "y2", "z2"), Fact.TRUE),
+            (("x1", "y3", "z3"), Fact.TRUE),
+            (("x4", "y1", "z1"), Fact.TRUE),
+            (("x4", "y3", "z3"), Fact.TRUE),
+            (("x4", "y2", "z2"), Fact.TRUE),
+        ]
+    )
 
-    assert (v1_after == v1_before),  "FAILED 😔"
-    assert (v2_after == v2_before),  "FAILED 😔"
-    assert (v3_after == v3_before),  "FAILED 😔"
+    assert v1_after == v1_before, "FAILED 😔"
+    assert v2_after == v2_before, "FAILED 😔"
+    assert v3_after == v3_before, "FAILED 😔"
 
-    assert all([model['t2_p3_and_t2_p2_t4_p1'].state(groundings=g)
-                is GT_o[g] for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t4_p1'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t4_p1"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t4_p1"].state()) == len(GT_o), "FAILED 😔"
 
     # TEST 5
     model = Model()
-    model['t2_p3'] = Predicate('t2_p3', arity=3)
-    model.add_facts({'t2_p3': {
-        ('x1', 'y1', 'z1'): Fact.TRUE,
-        ('x3', 'y3', 'z3'): Fact.TRUE}})
+    model["t2_p3"] = Predicate("t2_p3", arity=3)
+    model.add_facts(
+        {"t2_p3": {("x1", "y1", "z1"): Fact.TRUE, ("x3", "y3", "z3"): Fact.TRUE}}
+    )
 
-    model['t2_p2'] = Predicate('t2_p2', arity=2)
-    model.add_facts({'t2_p2': {
-        ('y1', 'z1'): Fact.TRUE,
-        ('y2', 'z2'): Fact.TRUE}})
+    model["t2_p2"] = Predicate("t2_p2", arity=2)
+    model.add_facts({"t2_p2": {("y1", "z1"): Fact.TRUE, ("y2", "z2"): Fact.TRUE}})
 
-    model['t5_p2'] = Predicate('t5_p2', arity=2)
-    model.add_facts({'t5_p2': {
-        ('a1', 'b1'): Fact.TRUE,
-        ('a2', 'b2'): Fact.TRUE}})
+    model["t5_p2"] = Predicate("t5_p2", arity=2)
+    model.add_facts({"t5_p2": {("a1", "b1"): Fact.TRUE, ("a2", "b2"): Fact.TRUE}})
 
-    model['t2_p3_and_t2_p2_t5_p2'] = And(model['t2_p3'](x, y, z),
-                                         model['t2_p2'](y, z),
-                                         model['t5_p2'](a, b),
-                                         join=join)
+    model["t2_p3_and_t2_p2_t5_p2"] = And(
+        model["t2_p3"](x, y, z), model["t2_p2"](y, z), model["t5_p2"](a, b), join=join
+    )
 
-    v1_before = model['t2_p3'].state()
-    v2_before = model['t2_p2'].state()
-    v3_before = model['t5_p2'].state()
+    v1_before = model["t2_p3"].state()
+    v2_before = model["t2_p2"].state()
+    v3_before = model["t5_p2"].state()
 
-    model['t2_p3_and_t2_p2_t5_p2'].upward()
+    model["t2_p3_and_t2_p2_t5_p2"].upward()
 
-    v1_after = model['t2_p3'].state()
-    v2_after = model['t2_p2'].state()
-    v3_after = model['t5_p2'].state()
+    v1_after = model["t2_p3"].state()
+    v2_after = model["t2_p2"].state()
+    v3_after = model["t5_p2"].state()
 
-    GT_o = dict([
-        (('x1', 'y1', 'z1', 'a1', 'b1'), Fact.TRUE),
-        (('x1', 'y2', 'z2', 'a1', 'b1'), Fact.TRUE),
-        (('x3', 'y1', 'z1', 'a1', 'b1'), Fact.TRUE),
-        (('x3', 'y3', 'z3', 'a1', 'b1'), Fact.TRUE),
-        (('x3', 'y2', 'z2', 'a1', 'b1'), Fact.TRUE),
-        (('x1', 'y1', 'z1', 'a2', 'b2'), Fact.TRUE),
-        (('x1', 'y2', 'z2', 'a2', 'b2'), Fact.TRUE),
-        (('x3', 'y1', 'z1', 'a2', 'b2'), Fact.TRUE),
-        (('x3', 'y3', 'z3', 'a2', 'b2'), Fact.TRUE),
-        (('x3', 'y2', 'z2', 'a2', 'b2'), Fact.TRUE)])
+    GT_o = dict(
+        [
+            (("x1", "y1", "z1", "a1", "b1"), Fact.TRUE),
+            (("x1", "y2", "z2", "a1", "b1"), Fact.TRUE),
+            (("x3", "y1", "z1", "a1", "b1"), Fact.TRUE),
+            (("x3", "y3", "z3", "a1", "b1"), Fact.TRUE),
+            (("x3", "y2", "z2", "a1", "b1"), Fact.TRUE),
+            (("x1", "y1", "z1", "a2", "b2"), Fact.TRUE),
+            (("x1", "y2", "z2", "a2", "b2"), Fact.TRUE),
+            (("x3", "y1", "z1", "a2", "b2"), Fact.TRUE),
+            (("x3", "y3", "z3", "a2", "b2"), Fact.TRUE),
+            (("x3", "y2", "z2", "a2", "b2"), Fact.TRUE),
+        ]
+    )
 
-    assert (v1_after == v1_before),  "FAILED 😔"
-    assert (v2_after == v2_before),  "FAILED 😔"
-    assert (v3_after == v3_before),  "FAILED 😔"
+    assert v1_after == v1_before, "FAILED 😔"
+    assert v2_after == v2_before, "FAILED 😔"
+    assert v3_after == v3_before, "FAILED 😔"
 
-    assert all([model['t2_p3_and_t2_p2_t5_p2'].state(groundings=g)
-                is GT_o[g] for g in GT_o]), "FAILED 😔"
-    assert len(model['t2_p3_and_t2_p2_t5_p2'].state()) == len(GT_o), "FAILED 😔"
+    assert all(
+        [model["t2_p3_and_t2_p2_t5_p2"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
+    assert len(model["t2_p3_and_t2_p2_t5_p2"].state()) == len(GT_o), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_gm_qa.py
+++ b/tests/reasoning/gm/test_gm_qa.py
@@ -9,63 +9,78 @@ from lnn import Model, Predicate, And, Fact, Exists, Variable, Join
 
 def test_1():
     join = Join.OUTER
-    x = Variable('x')
-    y = Variable('y')
+    x = Variable("x")
+    y = Variable("y")
 
     model = Model()
 
-    model['director'] = Predicate('director', arity=2)
-    model['starring'] = Predicate('starring', arity=2)
+    model["director"] = Predicate("director", arity=2)
+    model["starring"] = Predicate("starring", arity=2)
 
-    facts = {'director': {('William_Shatner', 'The_captains'): Fact.TRUE},
-             'starring': {('William_Shatner', 'The_captains'): Fact.TRUE,
-                          ('Patrick_Stewart', 'The_captains'): Fact.TRUE}
-             }
+    facts = {
+        "director": {("William_Shatner", "The_captains"): Fact.TRUE},
+        "starring": {
+            ("William_Shatner", "The_captains"): Fact.TRUE,
+            ("Patrick_Stewart", "The_captains"): Fact.TRUE,
+        },
+    }
     model.add_facts(facts)
 
-    query = Exists(x, And(model['director']((x, 'William_Shatner'), y),
-                          model['starring'](x, y),
-                          join=join),
-                   name='Shatner-stars')
+    query = Exists(
+        x,
+        And(
+            model["director"]((x, "William_Shatner"), y),
+            model["starring"](x, y),
+            join=join,
+        ),
+        name="Shatner-stars",
+    )
     model.add_formulae(query)
 
     model.infer()
 
-    assert query.true_groundings == {'William_Shatner'}
+    assert query.true_groundings == {"William_Shatner"}
 
 
 def test_2():
     join = Join.OUTER
-    x = Variable('x')
-    y = Variable('y')
-    z = Variable('z')
+    x = Variable("x")
+    y = Variable("y")
+    z = Variable("z")
 
     model = Model()
 
-    model['director'] = Predicate('director', arity=2)
-    model['starring'] = Predicate('starring', arity=2)
+    model["director"] = Predicate("director", arity=2)
+    model["starring"] = Predicate("starring", arity=2)
 
-    model.add_facts({'director': {('William_Shatner',
-                                   'The_captains'): Fact.TRUE},
-                     'starring': {('William_Shatner',
-                                   'The_captains'): Fact.TRUE,
-                                  ('Patrick_Stewart',
-                                   'The_captains'): Fact.TRUE}
-                     })
+    model.add_facts(
+        {
+            "director": {("William_Shatner", "The_captains"): Fact.TRUE},
+            "starring": {
+                ("William_Shatner", "The_captains"): Fact.TRUE,
+                ("Patrick_Stewart", "The_captains"): Fact.TRUE,
+            },
+        }
+    )
 
-    query = Exists(z, And(model['director']((x, 'William_Shatner'), y),
-                          model['starring'](z, y),
-                          join=join),
-                   name='Shatner-stars')
+    query = Exists(
+        z,
+        And(
+            model["director"]((x, "William_Shatner"), y),
+            model["starring"](z, y),
+            join=join,
+        ),
+        name="Shatner-stars",
+    )
     model.add_formulae(query)
 
     model.infer()
 
-    assert query.true_groundings == {'William_Shatner', 'Patrick_Stewart'}
+    assert query.true_groundings == {"William_Shatner", "Patrick_Stewart"}
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_1()
     test_2()
 
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_ilp_and_implies_1.py
+++ b/tests/reasoning/gm/test_ilp_and_implies_1.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, World, And, Variable,
-                 TRUE, UPWARD, Implies, Fact, Join)
+from lnn import Model, World, And, Variable, TRUE, UPWARD, Implies, Fact, Join
 
 
 def test_1():
@@ -15,48 +14,52 @@ def test_1():
     Closed World Assumption on isFather
     """
 
-    GT_i = {('a', 'b', 'c'): Fact.TRUE}
-    GT_o = dict([
-        (('a', 'b', 'b'), Fact.FALSE),
-        (('a', 'b', 'c'), Fact.TRUE),
-        (('b', 'c', 'b'), Fact.FALSE),
-        (('b', 'a', 'b'), Fact.FALSE),
-        (('b', 'c', 'c'), Fact.FALSE),
-        (('b', 'b', 'c'), Fact.FALSE),
-        (('a', 'a', 'b'), Fact.FALSE)])
-    GT_op = dict([
-        (('a', 'b', 'b'), Fact.TRUE),
-        (('a', 'b', 'c'), Fact.TRUE),
-        (('b', 'c', 'b'), Fact.TRUE),
-        (('b', 'a', 'b'), Fact.TRUE),
-        (('b', 'c', 'c'), Fact.TRUE),
-        (('b', 'b', 'c'), Fact.TRUE),
-        (('a', 'a', 'b'), Fact.TRUE)])
+    GT_i = {("a", "b", "c"): Fact.TRUE}
+    GT_o = dict(
+        [
+            (("a", "b", "b"), Fact.FALSE),
+            (("a", "b", "c"), Fact.TRUE),
+            (("b", "c", "b"), Fact.FALSE),
+            (("b", "a", "b"), Fact.FALSE),
+            (("b", "c", "c"), Fact.FALSE),
+            (("b", "b", "c"), Fact.FALSE),
+            (("a", "a", "b"), Fact.FALSE),
+        ]
+    )
+    GT_op = dict(
+        [
+            (("a", "b", "b"), Fact.TRUE),
+            (("a", "b", "c"), Fact.TRUE),
+            (("b", "c", "b"), Fact.TRUE),
+            (("b", "a", "b"), Fact.TRUE),
+            (("b", "c", "c"), Fact.TRUE),
+            (("b", "b", "c"), Fact.TRUE),
+            (("a", "a", "b"), Fact.TRUE),
+        ]
+    )
 
     for join, GT in zip([Join.INNER, Join.OUTER], [GT_i, GT_o, GT_op]):
 
         # background data (features)
-        B = ['isFather', [('a', 'b'), ('b', 'c')]]
+        B = ["isFather", [("a", "b"), ("b", "c")]]
 
-        x = Variable('x')
-        y = Variable('y')
-        z = Variable('z')
+        x = Variable("x")
+        y = Variable("y")
+        z = Variable("z")
 
         vars1 = (x, z)
         vars2 = (z, y)
 
         model = Model()
         b = model.add_predicates(2, B[0], world=World.FALSE)
-        model.add_facts({
-            b.name: {pair: TRUE for pair in B[1]}})
+        model.add_facts({b.name: {pair: TRUE for pair in B[1]}})
 
-        model['rule'] = And(b(*vars1), b(*vars2), join=join)
+        model["rule"] = And(b(*vars1), b(*vars2), join=join)
 
         model.infer(direction=UPWARD)
 
-        assert all([model['rule'].state(groundings=g) is GT[g]
-                    for g in GT]), "FAILED 😔"
-        assert len(model['rule'].groundings) == len(GT), "FAILED 😔"
+        assert all([model["rule"].state(groundings=g) is GT[g] for g in GT]), "FAILED 😔"
+        assert len(model["rule"].groundings) == len(GT), "FAILED 😔"
 
 
 def test_2():
@@ -65,51 +68,55 @@ def test_2():
     Using expanded outer joins
     Closed World Assumption on isFather and isGrandFather
     """
-    GT_i = {('a', 'c', 'b'): Fact.TRUE}
-    GT_o = dict([
-        (('a', 'b', 'b'), Fact.TRUE),
-        (('a', 'b', 'a'), Fact.TRUE),
-        (('a', 'c', 'a'), Fact.UNKNOWN),
-        (('a', 'c', 'b'), Fact.TRUE),
-        (('b', 'b', 'c'), Fact.TRUE),
-        (('b', 'c', 'c'), Fact.TRUE),
-        (('a', 'c', 'c'), Fact.UNKNOWN),
-        (('b', 'b', 'a'), Fact.TRUE),
-        (('b', 'c', 'b'), Fact.TRUE)],
+    GT_i = {("a", "c", "b"): Fact.TRUE}
+    GT_o = dict(
+        [
+            (("a", "b", "b"), Fact.TRUE),
+            (("a", "b", "a"), Fact.TRUE),
+            (("a", "c", "a"), Fact.UNKNOWN),
+            (("a", "c", "b"), Fact.TRUE),
+            (("b", "b", "c"), Fact.TRUE),
+            (("b", "c", "c"), Fact.TRUE),
+            (("a", "c", "c"), Fact.UNKNOWN),
+            (("b", "b", "a"), Fact.TRUE),
+            (("b", "c", "b"), Fact.TRUE),
+        ],
     )
 
     for join, GT in zip([Join.INNER, Join.OUTER], [GT_i, GT_o]):
         # background data (features)
-        B = ['isFather', [('a', 'b'), ('b', 'c')]]
+        B = ["isFather", [("a", "b"), ("b", "c")]]
 
         # positive (target) labels for isGrandFather(x,y)
-        P1 = ['isGrandFather', [('a', 'c')]]
+        P1 = ["isGrandFather", [("a", "c")]]
 
-        x = Variable('x')
-        y = Variable('y')
-        z = Variable('z')
+        x = Variable("x")
+        y = Variable("y")
+        z = Variable("z")
 
         vars1 = (x, z)
         vars2 = (z, y)
 
         model = Model()
         b, p = model.add_predicates(2, B[0], P1[0], world=World.FALSE)
-        model.add_facts({
-            b.name: {pair: TRUE for pair in B[1]},
-            p.name: {pair: TRUE for pair in P1[1]}})
+        model.add_facts(
+            {
+                b.name: {pair: TRUE for pair in B[1]},
+                p.name: {pair: TRUE for pair in P1[1]},
+            }
+        )
 
-        model['rule'] = Implies(p(x, y),
-                                And(b(*vars1), b(*vars2), join=join),
-                                join=join)
+        model["rule"] = Implies(
+            p(x, y), And(b(*vars1), b(*vars2), join=join), join=join
+        )
 
         model.infer(direction=UPWARD)
 
-        assert all([model['rule'].state(groundings=g) is GT[g]
-                    for g in GT]), "FAILED 😔"
-        assert len(model['rule'].groundings) == len(GT), "FAILED 😔"
+        assert all([model["rule"].state(groundings=g) is GT[g] for g in GT]), "FAILED 😔"
+        assert len(model["rule"].groundings) == len(GT), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test_1()
     test_2()
-    print('success')
+    print("success")

--- a/tests/reasoning/gm/test_shared_var_set.py
+++ b/tests/reasoning/gm/test_shared_var_set.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Predicate, Variable, And, Join,
-                 Implies, ForAll, Model, Fact, World)
+from lnn import Predicate, Variable, And, Join, Implies, ForAll, Model, Fact, World
 
 
 def test_1():
@@ -13,19 +12,21 @@ def test_1():
     Unary predicates with overlapping variable set.
     """
 
-    x = Variable('x')
-    square = Predicate(name='square')
-    rectangle = Predicate(name='rectangle')
+    x = Variable("x")
+    square = Predicate(name="square")
+    rectangle = Predicate(name="rectangle")
 
-    square_rect = ForAll(x, Implies(square(x), rectangle(x),
-                                    name='square-rect',
-                                    join=Join.OUTER),
-                         name='all-square-rect', join=Join.OUTER,
-                         world=World.AXIOM)
+    square_rect = ForAll(
+        x,
+        Implies(square(x), rectangle(x), name="square-rect", join=Join.OUTER),
+        name="all-square-rect",
+        join=Join.OUTER,
+        world=World.AXIOM,
+    )
 
     model = Model()
     model.add_formulae(square, rectangle, square_rect)
-    model.add_facts({'square': {'c': Fact.TRUE, 'k': Fact.TRUE}})
+    model.add_facts({"square": {"c": Fact.TRUE, "k": Fact.TRUE}})
 
     model.upward()
 
@@ -38,21 +39,24 @@ def test_2():
     :return:
     """
 
-    x, y = map(Variable, ['x', 'y'])
+    x, y = map(Variable, ["x", "y"])
     model = Model()  # Instantiate a model.
 
-    enemy = model['enemy'] = Predicate(arity=2, name='enemy')
-    hostile = model['hostile'] = Predicate(name='hostile')
+    enemy = model["enemy"] = Predicate(arity=2, name="enemy")
+    hostile = model["hostile"] = Predicate(name="hostile")
 
-    model['america-enemies'] = ForAll(x, Implies(enemy(x, (y, 'America')),
-                                                 hostile(x),
-                                                 name='enemy->hostile',
-                                                 join=Join.OUTER),
-                                      name='america-enemies', join=Join.OUTER,
-                                      world=World.AXIOM)
+    model["america-enemies"] = ForAll(
+        x,
+        Implies(
+            enemy(x, (y, "America")), hostile(x), name="enemy->hostile", join=Join.OUTER
+        ),
+        name="america-enemies",
+        join=Join.OUTER,
+        world=World.AXIOM,
+    )
 
     # Add facts to model.
-    model.add_facts({'enemy': {('Nono', 'America'): Fact.TRUE}})
+    model.add_facts({"enemy": {("Nono", "America"): Fact.TRUE}})
 
     model.upward()
     assert len(hostile.groundings) == 1, "FAILED 😔"
@@ -64,16 +68,16 @@ def test_3():
     :return:
     """
 
-    x, y, z = map(Variable, ['x', 'y', 'z'])
+    x, y, z = map(Variable, ["x", "y", "z"])
     model = Model()  # Instantiate a model.
 
-    f1 = Predicate(name='F1', arity=3)
-    f2 = Predicate(name='F2', arity=2)
+    f1 = Predicate(name="F1", arity=3)
+    f2 = Predicate(name="F2", arity=2)
 
     rule = And(f1(x, y, z), f2(x, y), join=Join.OUTER)
 
     model.add_formulae(f1, f2, rule)
-    model.add_facts({'F1': {('x1', 'y1', 'z1'): Fact.TRUE}})
+    model.add_facts({"F1": {("x1", "y1", "z1"): Fact.TRUE}})
 
     model.upward()
 
@@ -87,19 +91,22 @@ def test_4():
     :return:
     """
 
-    x, y, z = map(Variable, ['x', 'y', 'z'])
-    american = Predicate('american')
-    hostile = Predicate('hostile')
-    weapon = Predicate('weapon')
-    sells = Predicate(arity=3, name='sells')
+    x, y, z = map(Variable, ["x", "y", "z"])
+    american = Predicate("american")
+    hostile = Predicate("hostile")
+    weapon = Predicate("weapon")
+    sells = Predicate(arity=3, name="sells")
 
     model = Model()  # Instantiate a model.
-    rule = And(american(x), weapon(y), hostile(z), sells(x, y, z),
-               join=Join.OUTER)
+    rule = And(american(x), weapon(y), hostile(z), sells(x, y, z), join=Join.OUTER)
     model.add_formulae(american, hostile, weapon, rule)
-    model.add_facts({'american': {'West': Fact.TRUE},
-                     'hostile': {'Nono': Fact.TRUE},
-                     'weapon': {'m1': Fact.TRUE}})
+    model.add_facts(
+        {
+            "american": {"West": Fact.TRUE},
+            "hostile": {"Nono": Fact.TRUE},
+            "weapon": {"m1": Fact.TRUE},
+        }
+    )
 
     model.upward()
 
@@ -111,4 +118,4 @@ if __name__ == "__main__":
     test_2()
     test_3()
     test_4()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/fol/test_american.py
+++ b/tests/reasoning/logic/fol/test_american.py
@@ -4,82 +4,112 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Predicate, Variable, Join, And,
-                 Exists, Implies, ForAll, Model, Fact, World)
+from lnn import (
+    Predicate,
+    Variable,
+    Join,
+    And,
+    Exists,
+    Implies,
+    ForAll,
+    Model,
+    Fact,
+    World,
+)
 
 
 def test_1():
-    """The 'American' theorem proving example
+    """The 'American' theorem proving example"""
 
-    """
-
-    x, y, z, w = map(Variable, ['x', 'y', 'z', 'w'])
+    x, y, z, w = map(Variable, ["x", "y", "z", "w"])
     model = Model()  # Instantiate a model.
 
     # Define and add predicates to the model.
-    owns = model['owns'] = Predicate(arity=2, name='owns')
-    missile = model['missile'] = Predicate('missile')
-    american = model['american'] = Predicate('american')
-    enemy = model['enemy'] = Predicate(arity=2, name='enemy')
-    hostile = model['hostile'] = Predicate('hostile')
-    criminal = model['criminal'] = Predicate('criminal')
-    weapon = model['weapon'] = Predicate('weapon')
-    sells = model['sells'] = Predicate(arity=3, name='sells')
+    owns = model["owns"] = Predicate(arity=2, name="owns")
+    missile = model["missile"] = Predicate("missile")
+    american = model["american"] = Predicate("american")
+    enemy = model["enemy"] = Predicate(arity=2, name="enemy")
+    hostile = model["hostile"] = Predicate("hostile")
+    criminal = model["criminal"] = Predicate("criminal")
+    weapon = model["weapon"] = Predicate("weapon")
+    sells = model["sells"] = Predicate(arity=3, name="sells")
 
     # Define and add the background knowledge to  the model.
-    model['america-enemies'] = ForAll(x, Implies(enemy(x, (y, 'America')),
-                                                 hostile(x),
-                                                 name='enemy->hostile',
-                                                 join=Join.OUTER),
-                                      name='america-enemies', join=Join.OUTER,
-                                      world=World.AXIOM)
-    model['crime'] = ForAll(x, y, z, Implies(And(american(x), weapon(y),
-                                                 sells(x, y, z), hostile(z),
-                                                 name='american-to-hostile',
-                                                 join=Join.OUTER),
-                                             criminal(x),
-                                             name='implies-criminal',
-                                             join=Join.OUTER), name='crime',
-                            join=Join.OUTER, world=World.AXIOM)
-    model['nono_missiles_byWest'] = ForAll(x, Implies(And(missile(x),
-                                                          owns((y, 'Nono'), x),
-                                                          name='nono-missile',
-                                                          join=Join.OUTER),
-                                                      sells((z, 'West'), x,
-                                                            (y, 'Nono')),
-                                                      name='West-to-Nono',
-                                                      join=Join.OUTER),
-                                           name='nono_missiles_byWest',
-                                           join=Join.OUTER, world=World.AXIOM)
-    model['missiles-are-weapons'] = ForAll(x, Implies(missile(x), weapon(x),
-                                                      name='missile-weapon',
-                                                      join=Join.OUTER),
-                                           name='missiles-are-weapons',
-                                           join=Join.OUTER, world=World.AXIOM)
+    model["america-enemies"] = ForAll(
+        x,
+        Implies(
+            enemy(x, (y, "America")), hostile(x), name="enemy->hostile", join=Join.OUTER
+        ),
+        name="america-enemies",
+        join=Join.OUTER,
+        world=World.AXIOM,
+    )
+    model["crime"] = ForAll(
+        x,
+        y,
+        z,
+        Implies(
+            And(
+                american(x),
+                weapon(y),
+                sells(x, y, z),
+                hostile(z),
+                name="american-to-hostile",
+                join=Join.OUTER,
+            ),
+            criminal(x),
+            name="implies-criminal",
+            join=Join.OUTER,
+        ),
+        name="crime",
+        join=Join.OUTER,
+        world=World.AXIOM,
+    )
+    model["nono_missiles_byWest"] = ForAll(
+        x,
+        Implies(
+            And(missile(x), owns((y, "Nono"), x), name="nono-missile", join=Join.OUTER),
+            sells((z, "West"), x, (y, "Nono")),
+            name="West-to-Nono",
+            join=Join.OUTER,
+        ),
+        name="nono_missiles_byWest",
+        join=Join.OUTER,
+        world=World.AXIOM,
+    )
+    model["missiles-are-weapons"] = ForAll(
+        x,
+        Implies(missile(x), weapon(x), name="missile-weapon", join=Join.OUTER),
+        name="missiles-are-weapons",
+        join=Join.OUTER,
+        world=World.AXIOM,
+    )
 
     # Define queries
-    model['query'] = Exists(x, criminal(x), name='who-is-criminal',
-                            join=Join.OUTER)
+    model["query"] = Exists(x, criminal(x), name="who-is-criminal", join=Join.OUTER)
 
     # Add facts to model.
-    model.add_facts({'owns': {('Nono', 'M1'): Fact.TRUE},
-                     'missile': {'M1': Fact.TRUE},
-                     'american': {'West': Fact.TRUE},
-                     'enemy': {('Nono', 'America'): Fact.TRUE},
-                     })
+    model.add_facts(
+        {
+            "owns": {("Nono", "M1"): Fact.TRUE},
+            "missile": {"M1": Fact.TRUE},
+            "american": {"West": Fact.TRUE},
+            "enemy": {("Nono", "America"): Fact.TRUE},
+        }
+    )
 
     steps, facts_inferred = model.infer()
 
     # Currently finishes in 5 inference steps
     assert steps == 5, "FAILED 😔"
 
-    GT_o = dict([
-        (('West'), Fact.TRUE)])
+    GT_o = dict([(("West"), Fact.TRUE)])
 
-    assert all([model['query'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
+    assert all(
+        [model["query"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test_1()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/fol/test_quantifier_bound_var.py
+++ b/tests/reasoning/logic/fol/test_quantifier_bound_var.py
@@ -11,62 +11,54 @@ def test_1():
     """Quantifier with bounded variables, upward on predicate
     UNKNOWN result when not fully grounded
     """
-    x = Variable('x')
+    x = Variable("x")
     model = Model()
-    A, S = model.add_predicates(1, 'A', 'S')
-    All = model['All'] = ForAll(x, A(x))
-    Some = model['Some'] = Exists(x, S(x))
+    A, S = model.add_predicates(1, "A", "S")
+    All = model["All"] = ForAll(x, A(x))
+    Some = model["Some"] = Exists(x, S(x))
 
-    model.add_facts({
-        'A': {
-            '0': TRUE,
-            '1': TRUE,
-            '2': TRUE},
-        'S': {
-            '0': FALSE,
-            '1': FALSE,
-            '2': FALSE}
-        })
+    model.add_facts(
+        {
+            "A": {"0": TRUE, "1": TRUE, "2": TRUE},
+            "S": {"0": FALSE, "1": FALSE, "2": FALSE},
+        }
+    )
 
     model.upward()
     predictions = [All.state(), Some.state()]
     assert predictions[0] is UNKNOWN, (
-        f'ForAll expected as UNKNOWN, received {predictions[0]}'
-        'cannot learn to be TRUE unless fully grounded')
+        f"ForAll expected as UNKNOWN, received {predictions[0]}"
+        "cannot learn to be TRUE unless fully grounded"
+    )
     assert predictions[1] is UNKNOWN, (
-        f'Exists expected as UNKNOWN, received {predictions[1]}'
-        'cannot learn to be FALSE unless fully grounded')
+        f"Exists expected as UNKNOWN, received {predictions[1]}"
+        "cannot learn to be FALSE unless fully grounded"
+    )
 
 
 def test_2():
     """Quantifier with bounded variables, upward on predicate
     Single predicate truth updates quantifier truth
     """
-    x = Variable('x')
+    x = Variable("x")
     model = Model()
-    A, S = model.add_predicates(1, 'A', 'S')
-    All = model['All'] = ForAll(x, A(x))
-    Some = model['Some'] = Exists(x, S(x))
+    A, S = model.add_predicates(1, "A", "S")
+    All = model["All"] = ForAll(x, A(x))
+    Some = model["Some"] = Exists(x, S(x))
 
-    model.add_facts({
-        'A': {
-            '0': TRUE,
-            '1': TRUE,
-            '2': FALSE},
-        'S': {
-            '0': FALSE,
-            '1': FALSE,
-            '2': TRUE}
-        })
+    model.add_facts(
+        {
+            "A": {"0": TRUE, "1": TRUE, "2": FALSE},
+            "S": {"0": FALSE, "1": FALSE, "2": TRUE},
+        }
+    )
 
     model.upward()
-    assert Some.state() is TRUE, (
-        f'ForAll expected as TRUE, received {Some.state()}')
-    assert All.state() is FALSE, (
-        f'Exists expected as FALSE, received {All.state()}')
+    assert Some.state() is TRUE, f"ForAll expected as TRUE, received {Some.state()}"
+    assert All.state() is FALSE, f"Exists expected as FALSE, received {All.state()}"
 
 
 if __name__ == "__main__":
     test_1()
     test_2()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/fol/test_quantifier_free_var.py
+++ b/tests/reasoning/logic/fol/test_quantifier_free_var.py
@@ -9,93 +9,95 @@ from lnn import Model, Variable, TRUE, FALSE, UNKNOWN, ForAll, Exists
 
 def test_1():
     """Quantifier with free variables, upward on predicate"""
-    p, c = map(Variable, ('dbo:Person', 'dbo:City'))
+    p, c = map(Variable, ("dbo:Person", "dbo:City"))
     model = Model()
-    mayor = model.add_predicates(2, 'dbo:Mayor')
+    mayor = model.add_predicates(2, "dbo:Mayor")
 
     # List all the mayors of Boston
-    Some = model['Some'] = Exists(
-        p, mayor(p, c))
+    Some = model["Some"] = Exists(p, mayor(p, c))
 
-    GT = ['dbr:Marty_Walsh_(politician)', 'dbr:Lori_Lightfoot']
+    GT = ["dbr:Marty_Walsh_(politician)", "dbr:Lori_Lightfoot"]
 
-    model.add_facts({
-        mayor.name: {
-            ('dbr:Kim_Janey', 'dbr:Boston'): UNKNOWN,
-            (GT[0], 'dbr:Boston'): TRUE,
-            ('dbr:Tishaura_Jones', 'dbr:St._Louis'): UNKNOWN,
-            (GT[1], 'dbr:Chicago'): TRUE}
-        })
+    model.add_facts(
+        {
+            mayor.name: {
+                ("dbr:Kim_Janey", "dbr:Boston"): UNKNOWN,
+                (GT[0], "dbr:Boston"): TRUE,
+                ("dbr:Tishaura_Jones", "dbr:St._Louis"): UNKNOWN,
+                (GT[1], "dbr:Chicago"): TRUE,
+            }
+        }
+    )
 
     model.upward()
-    assert Some.true_groundings == set(GT), (
-        f'expected True groundings to be {GT}, received {Some.true_groundings}'
-    )
+    assert Some.true_groundings == set(
+        GT
+    ), f"expected True groundings to be {GT}, received {Some.true_groundings}"
 
 
 def test_2():
     """Quantifier with free variables, upward on predicate
     UNKNOWN result when not fully grounded
     """
-    p, c = map(Variable, ('dbo:Person', 'dbo:City'))
+    p, c = map(Variable, ("dbo:Person", "dbo:City"))
     model = Model()
-    mayor = model.add_predicates(2, 'dbo:Mayor')
+    mayor = model.add_predicates(2, "dbo:Mayor")
 
     # List all the mayors of Boston
-    Some = model['Some'] = Exists(
-        p, mayor(p, (c, ['dbr:Chicago', 'dbr:Boston'])))
+    Some = model["Some"] = Exists(p, mayor(p, (c, ["dbr:Chicago", "dbr:Boston"])))
 
-    GT_truth = ['dbr:Marty_Walsh_(politician)']
-    GT_bindings = [('dbr:Lori_Lightfoot', 'dbr:Chicago'),
-                   ('dbr:Kim_Janey', 'dbr:Boston'),
-                   (GT_truth[0], 'dbr:Boston')]
+    GT_truth = ["dbr:Marty_Walsh_(politician)"]
+    GT_bindings = [
+        ("dbr:Lori_Lightfoot", "dbr:Chicago"),
+        ("dbr:Kim_Janey", "dbr:Boston"),
+        (GT_truth[0], "dbr:Boston"),
+    ]
 
-    model.add_facts({
-        mayor.name: {
-            GT_bindings[0]: UNKNOWN,
-            GT_bindings[1]: UNKNOWN,
-            ('dbr:Tishaura_Jones', 'dbr:St._Louis'): UNKNOWN,
-            GT_bindings[2]: TRUE,
-        }})
+    model.add_facts(
+        {
+            mayor.name: {
+                GT_bindings[0]: UNKNOWN,
+                GT_bindings[1]: UNKNOWN,
+                ("dbr:Tishaura_Jones", "dbr:St._Louis"): UNKNOWN,
+                GT_bindings[2]: TRUE,
+            }
+        }
+    )
 
     model.upward()
     assert Some.groundings == set(GT_bindings), (
-        f'expected groundings to be bound to GT bindings {GT_bindings}, '
-        f'received {Some.groundings}')
+        f"expected groundings to be bound to GT bindings {GT_bindings}, "
+        f"received {Some.groundings}"
+    )
     assert Some.true_groundings == set(GT_truth), (
-        f'expected True groundings to be {GT_truth}, '
-        f'received {Some.true_groundings}')
+        f"expected True groundings to be {GT_truth}, "
+        f"received {Some.true_groundings}"
+    )
 
 
 def test_3():
     """Quantifier with free variables, upward on predicate
     Single predicate truth updates quantifier truth
     """
-    x = Variable('x')
+    x = Variable("x")
     model = Model()
-    A, S = model.add_predicates(1, 'A', 'S')
-    All = model['All'] = ForAll(x, A(x))
-    Some = model['Some'] = Exists(x, S(x))
+    A, S = model.add_predicates(1, "A", "S")
+    All = model["All"] = ForAll(x, A(x))
+    Some = model["Some"] = Exists(x, S(x))
 
-    model.add_facts({
-        'A': {
-            '0': TRUE,
-            '1': TRUE,
-            '2': FALSE},
-        'S': {
-            '0': FALSE,
-            '1': FALSE,
-            '2': TRUE}
-        })
+    model.add_facts(
+        {
+            "A": {"0": TRUE, "1": TRUE, "2": FALSE},
+            "S": {"0": FALSE, "1": FALSE, "2": TRUE},
+        }
+    )
 
     model.upward()
-    assert Some.state() is TRUE, (
-        f'ForAll expected as TRUE, received {Some.state()}')
-    assert All.state() is FALSE, (
-        f'Exists expected as FALSE, received {All.state()}')
+    assert Some.state() is TRUE, f"ForAll expected as TRUE, received {Some.state()}"
+    assert All.state() is FALSE, f"Exists expected as FALSE, received {All.state()}"
 
 
 if __name__ == "__main__":
     test_1()
     test_2()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/fol/test_rv_and_2.py
+++ b/tests/reasoning/logic/fol/test_rv_and_2.py
@@ -15,11 +15,11 @@ def test_and():
     steps = np.linspace(0, 1, samples)
     x_grid, y_grid = np.meshgrid(steps, steps)
 
-    x = Variable('x')
+    x = Variable("x")
     model = Model()
-    model['A'] = Predicate()
-    model['B'] = Predicate()
-    model['AB'] = And(model['A'](x), model['B'](x))
+    model["A"] = Predicate()
+    model["B"] = Predicate()
+    model["AB"] = And(model["A"](x), model["B"](x))
 
     for row in range(samples):
         for col in range(samples):
@@ -28,35 +28,37 @@ def test_and():
             a, b = x_grid[row][col], y_grid[row][col]
 
             # facts per model
-            model.add_facts({
-                'A': {
-                    f'({row}, {col})': (a, a),
-                },
-                'B': {
-                    f'({row}, {col})': (b, b),
+            model.add_facts(
+                {
+                    "A": {
+                        f"({row}, {col})": (a, a),
+                    },
+                    "B": {
+                        f"({row}, {col})": (b, b),
+                    },
                 }
-            })
+            )
 
             # ground truth
             GT = float(max(0, a + b - 1))
-            model.add_labels({
-                'AB': {f'({row}, {col})': (GT, GT)}})
+            model.add_labels({"AB": {f"({row}, {col})": (GT, GT)}})
 
     # evaluate the conjunction
-    model['AB'].upward()
+    model["AB"].upward()
 
     # test the prediction
-    for g in model['AB'].groundings:
-        prediction = model['AB'].get_facts(g)[0]
-        label = model['AB'].get_labels(g)[0]
+    for g in model["AB"].groundings:
+        prediction = model["AB"].get_facts(g)[0]
+        label = model["AB"].get_labels(g)[0]
         lower_bound = prediction[0].item()
         upper_bound = prediction[1].item()
-        assert lower_bound == upper_bound, (
-            f'Expected upper and lower bound to be the same but \
-            got {lower_bound}, {upper_bound}'
-        )
-        assert round(lower_bound, 4) == round(label.item(), 4), (
-            f'And({a}, {b}) expected {label}, but got {lower_bound}')
+        assert (
+            lower_bound == upper_bound
+        ), f"Expected upper and lower bound to be the same but \
+            got {lower_bound}, {upper_bound}"
+        assert round(lower_bound, 4) == round(
+            label.item(), 4
+        ), f"And({a}, {b}) expected {label}, but got {lower_bound}"
 
 
 def test_or():
@@ -66,11 +68,11 @@ def test_or():
     steps = np.linspace(0, 1, samples)
     x_grid, y_grid = np.meshgrid(steps, steps)
 
-    x = Variable('x')
+    x = Variable("x")
     model = Model()
-    model['A'] = Predicate()
-    model['B'] = Predicate()
-    model['AB'] = Or(model['A'](x), model['B'](x))
+    model["A"] = Predicate()
+    model["B"] = Predicate()
+    model["AB"] = Or(model["A"](x), model["B"](x))
 
     for row in range(samples):
         for col in range(samples):
@@ -78,35 +80,37 @@ def test_or():
             a, b = x_grid[row][col], y_grid[row][col]
 
             # facts per model
-            model.add_facts({
-                'A': {
-                    f'({row}, {col})': (a, a),
-                },
-                'B': {
-                    f'({row}, {col})': (b, b),
+            model.add_facts(
+                {
+                    "A": {
+                        f"({row}, {col})": (a, a),
+                    },
+                    "B": {
+                        f"({row}, {col})": (b, b),
+                    },
                 }
-            })
+            )
 
             # ground truth
             GT = float(min(1, a + b))
-            model.add_labels({
-                'AB': {f'({row}, {col})': (GT, GT)}})
+            model.add_labels({"AB": {f"({row}, {col})": (GT, GT)}})
 
     # evaluate the conjunction
-    model['AB'].upward()
+    model["AB"].upward()
 
     # test the prediction
-    for g in model['AB'].groundings:
-        prediction = model['AB'].get_facts(g)[0]
-        label = model['AB'].get_labels(g)[0]
+    for g in model["AB"].groundings:
+        prediction = model["AB"].get_facts(g)[0]
+        label = model["AB"].get_labels(g)[0]
         lower_bound = prediction[0].item()
         upper_bound = prediction[1].item()
-        assert lower_bound == upper_bound, (
-            f'Expected upper and lower bound to be the same but \
-                got {lower_bound}, {upper_bound}'
-        )
-        assert round(lower_bound, 4) == round(label.item(), 4), (
-            f'And({a}, {b}) expected {label}, but got {lower_bound}')
+        assert (
+            lower_bound == upper_bound
+        ), f"Expected upper and lower bound to be the same but \
+                got {lower_bound}, {upper_bound}"
+        assert round(lower_bound, 4) == round(
+            label.item(), 4
+        ), f"And({a}, {b}) expected {label}, but got {lower_bound}"
 
 
 def test_implies():
@@ -116,11 +120,11 @@ def test_implies():
     steps = np.linspace(0, 1, samples)
     x_grid, y_grid = np.meshgrid(steps, steps)
 
-    x = Variable('x')
+    x = Variable("x")
     model = Model()
-    model['A'] = Predicate()
-    model['B'] = Predicate()
-    model['AB'] = Implies(model['A'](x), model['B'](x))
+    model["A"] = Predicate()
+    model["B"] = Predicate()
+    model["AB"] = Implies(model["A"](x), model["B"](x))
 
     for row in range(samples):
         for col in range(samples):
@@ -128,35 +132,37 @@ def test_implies():
             a, b = x_grid[row][col], y_grid[row][col]
 
             # facts per model
-            model.add_facts({
-                'A': {
-                    f'({row}, {col})': (a, a),
-                },
-                'B': {
-                    f'({row}, {col})': (b, b),
+            model.add_facts(
+                {
+                    "A": {
+                        f"({row}, {col})": (a, a),
+                    },
+                    "B": {
+                        f"({row}, {col})": (b, b),
+                    },
                 }
-            })
+            )
 
             # ground truth
             GT = float(min(1, 1 - a + b))
-            model.add_labels({
-                'AB': {f'({row}, {col})': (GT, GT)}})
+            model.add_labels({"AB": {f"({row}, {col})": (GT, GT)}})
 
     # evaluate the conjunction
-    model['AB'].upward()
+    model["AB"].upward()
 
     # test the prediction
-    for g in model['AB'].groundings:
-        prediction = model['AB'].get_facts(g)[0]
-        label = model['AB'].get_labels(g)[0]
+    for g in model["AB"].groundings:
+        prediction = model["AB"].get_facts(g)[0]
+        label = model["AB"].get_labels(g)[0]
         lower_bound = prediction[0].item()
         upper_bound = prediction[1].item()
-        assert lower_bound == upper_bound, (
-            f'Expected upper and lower bound to be the same but \
-                got {lower_bound}, {upper_bound}'
-        )
-        assert round(lower_bound, 4) == round(label.item(), 4), (
-            f'And({a}, {b}) expected {label}, but got {lower_bound}')
+        assert (
+            lower_bound == upper_bound
+        ), f"Expected upper and lower bound to be the same but \
+                got {lower_bound}, {upper_bound}"
+        assert round(lower_bound, 4) == round(
+            label.item(), 4
+        ), f"And({a}, {b}) expected {label}, but got {lower_bound}"
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/logic/fol/test_square_rectangle.py
+++ b/tests/reasoning/logic/fol/test_square_rectangle.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Predicate, Variable,
-                 Exists, Implies, ForAll, Model, Fact, World)
+from lnn import Predicate, Variable, Exists, Implies, ForAll, Model, Fact, World
 
 
 def test_1():
@@ -15,35 +14,40 @@ def test_1():
 
     """
 
-    x = Variable('x')
-    square = Predicate(name='square')
-    rectangle = Predicate(name='rectangle')
-    foursides = Predicate(name='foursides')
-    square_rect = ForAll(x, Implies(square(x), rectangle(x),
-                                    name='square-rect'),
-                         name='all-square-rect', world=World.AXIOM)
-    rect_foursides = ForAll(x, Implies(rectangle(x), foursides(x),
-                                       name='rect-foursides'),
-                            name='all-rect-foursides', world=World.AXIOM)
-    query = Exists(x, foursides(x), name='foursided_objects')
+    x = Variable("x")
+    square = Predicate(name="square")
+    rectangle = Predicate(name="rectangle")
+    foursides = Predicate(name="foursides")
+    square_rect = ForAll(
+        x,
+        Implies(square(x), rectangle(x), name="square-rect"),
+        name="all-square-rect",
+        world=World.AXIOM,
+    )
+    rect_foursides = ForAll(
+        x,
+        Implies(rectangle(x), foursides(x), name="rect-foursides"),
+        name="all-rect-foursides",
+        world=World.AXIOM,
+    )
+    query = Exists(x, foursides(x), name="foursided_objects")
 
     model = Model()
     model.add_formulae(square, rectangle, square_rect, rect_foursides, query)
-    model.add_facts({'square': {'c': Fact.TRUE, 'k': Fact.TRUE}})
+    model.add_facts({"square": {"c": Fact.TRUE, "k": Fact.TRUE}})
 
     steps, facts_inferred = model.infer()
 
     # Currently finishes in 4 inference steps
     assert steps == 4, "FAILED 😔"
 
-    GT_o = dict([
-        (('c'), Fact.TRUE),
-        (('k'), Fact.TRUE)])
+    GT_o = dict([(("c"), Fact.TRUE), (("k"), Fact.TRUE)])
 
-    assert all([model['foursided_objects'].state(groundings=g) is GT_o[g]
-                for g in GT_o]), "FAILED 😔"
+    assert all(
+        [model["foursided_objects"].state(groundings=g) is GT_o[g] for g in GT_o]
+    ), "FAILED 😔"
 
 
 if __name__ == "__main__":
     test_1()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_and_lukasiewicz_1.py
+++ b/tests/reasoning/logic/propositional/test_and_lukasiewicz_1.py
@@ -16,9 +16,9 @@ def test():
     x, y = np.meshgrid(steps, steps)
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = And(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = And(A, B, name="AB")
 
     # rules per model
     formulae = [AB]
@@ -32,7 +32,7 @@ def test():
             GT = max(0, a + b - 1)
 
             # facts per model
-            facts = {'A': (a, a), 'B': (b, b)}
+            facts = {"A": (a, a), "B": (b, b)}
 
             # load data into a new model
             model = Model()
@@ -40,14 +40,15 @@ def test():
             model.add_facts(facts)
 
             # evaluate the conjunction
-            model['AB'].upward()
+            model["AB"].upward()
 
             # test the prediction
-            prediction = model['AB'].get_facts()[0]
-            assert prediction - GT <= 1e-7, (
-                f'And({a}, {b}) expected {GT}, received {prediction}')
+            prediction = model["AB"].get_facts()[0]
+            assert (
+                prediction - GT <= 1e-7
+            ), f"And({a}, {b}) expected {GT}, received {prediction}"
             model.flush()
-    print('success')
+    print("success")
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/logic/propositional/test_api_syntax.py
+++ b/tests/reasoning/logic/propositional/test_api_syntax.py
@@ -10,23 +10,18 @@ from lnn import Model, TRUE, AXIOM
 def test():
     model = Model()
 
-    smokes,  friends = model.add_propositions("Smokes", "Friends")
+    smokes, friends = model.add_propositions("Smokes", "Friends")
     # check that more propositions can be added
     colleagues, gender = model.add_propositions("Colleagues", "GenderAlike")
     assert colleagues.name == "Colleagues"
     assert gender.name == "GenderAlike"
 
-    formula = smokes.And(colleagues, gender).Implies(
-        friends, world=AXIOM)
+    formula = smokes.And(colleagues, gender).Implies(friends, world=AXIOM)
 
-    facts = {
-      'Smokes': TRUE,
-      'Colleagues': TRUE,
-      'GenderAlike': TRUE
-    }
+    facts = {"Smokes": TRUE, "Colleagues": TRUE, "GenderAlike": TRUE}
 
     model.add_formulae(formula)
     model.add_facts(facts)
     model.infer()
     model.print()
-    assert model['Friends'].state() == TRUE, "Not friends :-("
+    assert model["Friends"].state() == TRUE, "Not friends :-("

--- a/tests/reasoning/logic/propositional/test_bool_and_0.py
+++ b/tests/reasoning/logic/propositional/test_bool_and_0.py
@@ -14,26 +14,24 @@ def test_upward():
     model = Model()
 
     # define the rules
-    A, B = model.add_propositions('A', 'B')
-    model['AB'] = Or(A, B)
+    A, B = model.add_propositions("A", "B")
+    model["AB"] = Or(A, B)
 
     # set the facts
-    model.add_facts({
-        'A': TRUE,
-        'B': FALSE,
-    })
+    model.add_facts(
+        {
+            "A": TRUE,
+            "B": FALSE,
+        }
+    )
 
     # set labels
-    model.add_labels({
-        'AB': FALSE
-    })
+    model.add_labels({"AB": FALSE})
 
     # learning/reasoning
-    losses = {'supervised': None, 'logical': 1e-1, 'contradiction': None}
-    parameter_history = {'weights': True, 'bias': True}
-    total_loss, _ = model.train(
-        losses=losses,
-        parameter_history=parameter_history)
+    losses = {"supervised": None, "logical": 1e-1, "contradiction": None}
+    parameter_history = {"weights": True, "bias": True}
+    total_loss, _ = model.train(losses=losses, parameter_history=parameter_history)
 
     # evaluation
     model.print(params=True)
@@ -44,4 +42,4 @@ def test_upward():
 
 if __name__ == "__main__":
     test_upward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_bool_and_1.py
+++ b/tests/reasoning/logic/propositional/test_bool_and_1.py
@@ -5,17 +5,27 @@
 ##
 
 import numpy as np
-from lnn import (Proposition, And, Model, TRUE, FALSE, UNKNOWN, CONTRADICTION,
-                 truth_table, fact_to_bool, bool_to_fact)
+from lnn import (
+    Proposition,
+    And,
+    Model,
+    TRUE,
+    FALSE,
+    UNKNOWN,
+    CONTRADICTION,
+    truth_table,
+    fact_to_bool,
+    bool_to_fact,
+)
 
 
 def test_upward():
     """standard upward, 2-input conjunction boolean truth table"""
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = And(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = And(A, B, name="AB")
     formulae = [AB]
 
     for row in truth_table(2):
@@ -23,122 +33,125 @@ def test_upward():
         GT = np.logical_and(*list(map(fact_to_bool, row)))
 
         # load model and reason over facts
-        facts = {'A': row[0], 'B': row[1]}
+        facts = {"A": row[0], "B": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].upward()
+        model["AB"].upward()
 
         # evaluate the conjunction
-        prediction = model['AB'].state()
-        assert prediction is bool_to_fact(GT), (
-            f'And({row[0]}, {row[1]}) expected {GT}, received {prediction}')
+        prediction = model["AB"].state()
+        assert prediction is bool_to_fact(
+            GT
+        ), f"And({row[0]}, {row[1]}) expected {GT}, received {prediction}"
         model.flush()
 
 
 def test_downward():
     # define model rules
     model = Model()
-    A = model['A'] = Proposition('A')
-    B = model['B'] = Proposition('B')
-    model['AB'] = And(A, B)
+    A = model["A"] = Proposition("A")
+    B = model["B"] = Proposition("B")
+    model["AB"] = And(A, B)
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'AB': FALSE,
-    })
-    model['AB'].downward()
+    model.add_facts(
+        {
+            "A": TRUE,
+            "AB": FALSE,
+        }
+    )
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be TRUE, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is FALSE, (
-        f'Expected input B to be False, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be TRUE, received {prediction}"
+    prediction = model["B"].state()
+    assert prediction is FALSE, f"Expected input B to be False, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({'AB': TRUE})
-    model['AB'].downward()
+    model.add_facts({"AB": TRUE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be TRUE, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is TRUE, (
-        f'Expected input B to be TRUE, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be TRUE, received {prediction}"
+    prediction = model["B"].state()
+    assert prediction is TRUE, f"Expected input B to be TRUE, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': FALSE,
-        'AB': FALSE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": FALSE, "AB": FALSE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is FALSE, (
-        f'Expected input A to be False, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is UNKNOWN, (
-        f'Expected input B to be Unknown, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is FALSE, f"Expected input A to be False, received {prediction}"
+    prediction = model["B"].state()
+    assert (
+        prediction is UNKNOWN
+    ), f"Expected input B to be Unknown, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': FALSE,
-        'AB': TRUE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": FALSE, "AB": TRUE})
+    model["AB"].downward()
 
     # evaluate
-    assert model['A'].state() is CONTRADICTION, (
-        f'Expected input B to be Contradiction, received {prediction}')
-    assert model['B'].state() is TRUE, (
-        f'Expected input B to be Contradiction, received {prediction}')
+    assert (
+        model["A"].state() is CONTRADICTION
+    ), f"Expected input B to be Contradiction, received {prediction}"
+    assert (
+        model["B"].state() is TRUE
+    ), f"Expected input B to be Contradiction, received {prediction}"
     model.flush()
 
     # define model facts
-    model['AB'].downward()
+    model["AB"].downward()
 
     # evaluate
-    assert model['A'].state() is UNKNOWN, (
-        f'Expected input B to be Unknown, received {prediction}')
-    assert model['B'].state() is UNKNOWN, (
-        f'Expected input B to be Unknown, received {prediction}')
+    assert (
+        model["A"].state() is UNKNOWN
+    ), f"Expected input B to be Unknown, received {prediction}"
+    assert (
+        model["B"].state() is UNKNOWN
+    ), f"Expected input B to be Unknown, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({'A': TRUE})
-    model['AB'].downward()
+    model.add_facts({"A": TRUE})
+    model["AB"].downward()
 
     # evaluate
-    assert model['A'].state() is TRUE, (
-        f'Expected input B to be Unknown, received {prediction}')
-    assert model['B'].state() is UNKNOWN, (
-        f'Expected input B to be Unknown, received {prediction}')
+    assert (
+        model["A"].state() is TRUE
+    ), f"Expected input B to be Unknown, received {prediction}"
+    assert (
+        model["B"].state() is UNKNOWN
+    ), f"Expected input B to be Unknown, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'B': FALSE,
-    })
-    model['AB'].downward()
+    model.add_facts(
+        {
+            "A": TRUE,
+            "B": FALSE,
+        }
+    )
+    model["AB"].downward()
 
     # evaluate
-    assert model['A'].state() is TRUE, (
-        f'Expected input B to be Unknown, received {prediction}')
-    assert model['B'].state() is FALSE, (
-        f'Expected input B to be False, received {prediction}')
+    assert (
+        model["A"].state() is TRUE
+    ), f"Expected input B to be Unknown, received {prediction}"
+    assert (
+        model["B"].state() is FALSE
+    ), f"Expected input B to be False, received {prediction}"
     model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_bool_and_2.py
+++ b/tests/reasoning/logic/propositional/test_bool_and_2.py
@@ -7,8 +7,7 @@
 from functools import reduce
 
 import numpy as np
-from lnn import (Proposition, And, Model,
-                 truth_table, fact_to_bool, bool_to_fact)
+from lnn import Proposition, And, Model, truth_table, fact_to_bool, bool_to_fact
 
 
 def test():
@@ -17,10 +16,10 @@ def test():
     TT = truth_table(3)
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    C = Proposition('C')
-    A_B_C = And(A, B, C, name='A_B_C')
+    A = Proposition("A")
+    B = Proposition("B")
+    C = Proposition("C")
+    A_B_C = And(A, B, C, name="A_B_C")
 
     formulae = [A_B_C]
 
@@ -29,7 +28,7 @@ def test():
         GT = reduce(np.logical_and, map(fact_to_bool, row))
 
         # facts per model
-        facts = {'A': row[0], 'B': row[1], 'C': row[2]}
+        facts = {"A": row[0], "B": row[1], "C": row[2]}
 
         # load data into a new model
         model = Model()
@@ -37,14 +36,15 @@ def test():
         model.add_facts(facts)
 
         # evaluate the conjunction
-        model['A_B_C'].upward()
+        model["A_B_C"].upward()
 
         # test the prediction
-        prediction = model['A_B_C'].state()
-        assert prediction is bool_to_fact(GT), (
-            f'And{row} expected {bool_to_fact(GT)}, received {prediction}')
+        prediction = model["A_B_C"].state()
+        assert prediction is bool_to_fact(
+            GT
+        ), f"And{row} expected {bool_to_fact(GT)}, received {prediction}"
         model.flush()
-    print('success')
+    print("success")
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/logic/propositional/test_bool_and_n.py
+++ b/tests/reasoning/logic/propositional/test_bool_and_n.py
@@ -14,8 +14,8 @@ def test_upward():
     n = 1000
     propositions = list()
     for i in range(1, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [And(*propositions, name='And_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [And(*propositions, name="And_n")]
 
     dat = np.random.random(n)
     row = list(map(lambda x: TRUE if x >= 0.5 else FALSE, dat))
@@ -29,47 +29,44 @@ def test_upward():
     # load model and reason over facts
     facts = {}
     for i in range(1, n):
-        facts['p' + str(i)] = row[i]
+        facts["p" + str(i)] = row[i]
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['And_n'].upward()
+    model["And_n"].upward()
 
     # evaluate the conjunction
-    prediction = model['And_n'].state()
-    assert prediction is GT, (
-        f'And({row}) expected {GT}, received {prediction}')
+    prediction = model["And_n"].state()
+    assert prediction is GT, f"And({row}) expected {GT}, received {prediction}"
     model.flush()
 
     # Test the case of all True
     for i in range(1, n):
-        facts['p' + str(i)] = TRUE
+        facts["p" + str(i)] = TRUE
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['And_n'].upward()
+    model["And_n"].upward()
 
     # evaluate the conjunction
-    prediction = model['And_n'].state()
-    assert prediction is TRUE, (
-        f'And({row}) expected {GT}, received {prediction}')
+    prediction = model["And_n"].state()
+    assert prediction is TRUE, f"And({row}) expected {GT}, received {prediction}"
     model.flush()
 
     # Test the case of all False
     for i in range(1, n):
-        facts['p' + str(i)] = FALSE
+        facts["p" + str(i)] = FALSE
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['And_n'].upward()
+    model["And_n"].upward()
 
     # evaluate the conjunction
-    prediction = model['And_n'].state()
-    assert prediction is FALSE, (
-        f'And({row}) expected {GT}, received {prediction}')
+    prediction = model["And_n"].state()
+    assert prediction is FALSE, f"And({row}) expected {GT}, received {prediction}"
     model.flush()
 
 
@@ -78,86 +75,78 @@ def test_downward():
     n = 1000
     propositions = list()
     for i in range(1, n):
-        propositions.append(Proposition('p' + str(i)))
+        propositions.append(Proposition("p" + str(i)))
 
     model = Model()
-    model['A'] = propositions[0]
-    for i in range(1, n-1):
-        model['P' + str(i)] = propositions[i]
-    model['And_n'] = And(*propositions)
+    model["A"] = propositions[0]
+    for i in range(1, n - 1):
+        model["P" + str(i)] = propositions[i]
+    model["And_n"] = And(*propositions)
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'And_n': TRUE,
-    })
-    model['And_n'].downward()
+    model.add_facts(
+        {
+            "A": TRUE,
+            "And_n": TRUE,
+        }
+    )
+    model["And_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be True, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be True, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is TRUE, (
-            f'Expected input to be True, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert prediction is TRUE, f"Expected input to be True, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': FALSE,
-        'And_n': TRUE
-    })
-    model['And_n'].downward()
+    model.add_facts({"A": FALSE, "And_n": TRUE})
+    model["And_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is CONTRADICTION, (
-        f'Expected input A to be Contradiction, received {prediction}')
+    prediction = model["A"].state()
+    assert (
+        prediction is CONTRADICTION
+    ), f"Expected input A to be Contradiction, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is TRUE, (
-            f'Expected input to be True, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert prediction is TRUE, f"Expected input to be True, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'And_n': FALSE
-    })
-    model['And_n'].downward()
+    model.add_facts({"A": TRUE, "And_n": FALSE})
+    model["And_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be True, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be True, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is UNKNOWN, (
-            f'Expected input to be Unknown, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert (
+            prediction is UNKNOWN
+        ), f"Expected input to be Unknown, received {prediction}"
     model.flush()
 
     # Test the case of all True except one
-    model.add_facts({'P' + str(i): TRUE for i in range(1, n-1)})
-    model.add_facts({'And_n': FALSE})
-    model['And_n'].downward()
+    model.add_facts({"P" + str(i): TRUE for i in range(1, n - 1)})
+    model.add_facts({"And_n": FALSE})
+    model["And_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is FALSE, (
-        f'Expected input A to be False, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is FALSE, f"Expected input A to be False, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is TRUE, (
-            f'Expected input to be True, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert prediction is TRUE, f"Expected input to be True, received {prediction}"
     model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_bool_implies_1.py
+++ b/tests/reasoning/logic/propositional/test_bool_implies_1.py
@@ -5,111 +5,103 @@
 ##
 
 import numpy as np
-from lnn import (Proposition, Implies, Model,
-                 CONTRADICTION, TRUE, FALSE, UNKNOWN,
-                 truth_table, fact_to_bool, bool_to_fact)
+from lnn import (
+    Proposition,
+    Implies,
+    Model,
+    CONTRADICTION,
+    TRUE,
+    FALSE,
+    UNKNOWN,
+    truth_table,
+    fact_to_bool,
+    bool_to_fact,
+)
 
 
 def test_upward():
     """standard upward 2-input implication boolean truth table"""
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = Implies(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = Implies(A, B, name="AB")
     formulae = [AB]
 
     for row in truth_table(2):
         # get ground truth
-        GT = np.logical_or(
-            np.logical_not(fact_to_bool(row[0])),
-            fact_to_bool(row[1]))
+        GT = np.logical_or(np.logical_not(fact_to_bool(row[0])), fact_to_bool(row[1]))
 
         # load model and reason over facts
-        facts = {'A': row[0], 'B': row[1]}
+        facts = {"A": row[0], "B": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].upward()
+        model["AB"].upward()
 
         # evaluate the conjunction
-        prediction = model['AB'].state()
-        assert prediction is bool_to_fact(GT), (
-            f'And({row[0]}, {row[1]}) expected {GT}, received {prediction}')
+        prediction = model["AB"].state()
+        assert prediction is bool_to_fact(
+            GT
+        ), f"And({row[0]}, {row[1]}) expected {GT}, received {prediction}"
         model.flush()
 
 
 def test_downward():
     # define model rules
     model = Model()
-    model['A'] = Proposition('A')
-    model['B'] = Proposition('B')
-    model['AB'] = Implies(model['A'], model['B'])
+    model["A"] = Proposition("A")
+    model["B"] = Proposition("B")
+    model["AB"] = Implies(model["A"], model["B"])
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'AB': TRUE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": TRUE, "AB": TRUE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be True, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is TRUE, (
-        f'Expected input B to be True, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be True, received {prediction}"
+    prediction = model["B"].state()
+    assert prediction is TRUE, f"Expected input B to be True, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'AB': FALSE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": TRUE, "AB": FALSE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be True, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is FALSE, (
-        f'Expected input B to be False, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be True, received {prediction}"
+    prediction = model["B"].state()
+    assert prediction is FALSE, f"Expected input B to be False, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': FALSE,
-        'AB': TRUE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": FALSE, "AB": TRUE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is FALSE, (
-        f'Expected input A to be False, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is UNKNOWN, (
-        f'Expected input B to be Unknown, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is FALSE, f"Expected input A to be False, received {prediction}"
+    prediction = model["B"].state()
+    assert (
+        prediction is UNKNOWN
+    ), f"Expected input B to be Unknown, received {prediction}"
 
     # define model facts
-    model.add_facts({
-        'A': FALSE,
-        'AB': FALSE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": FALSE, "AB": FALSE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is CONTRADICTION, (
-        f'Expected input A to be Contradiction, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is FALSE, (
-        f'Expected input B to be False, received {prediction}')
+    prediction = model["A"].state()
+    assert (
+        prediction is CONTRADICTION
+    ), f"Expected input A to be Contradiction, received {prediction}"
+    prediction = model["B"].state()
+    assert prediction is FALSE, f"Expected input B to be False, received {prediction}"
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_bool_or_1.py
+++ b/tests/reasoning/logic/propositional/test_bool_or_1.py
@@ -5,8 +5,18 @@
 ##
 
 import numpy as np
-from lnn import (Proposition, Or, Model, TRUE, FALSE, UNKNOWN, CONTRADICTION,
-                 truth_table, fact_to_bool, bool_to_fact)
+from lnn import (
+    Proposition,
+    Or,
+    Model,
+    TRUE,
+    FALSE,
+    UNKNOWN,
+    CONTRADICTION,
+    truth_table,
+    fact_to_bool,
+    bool_to_fact,
+)
 
 
 def test_upward():
@@ -15,9 +25,9 @@ def test_upward():
     TT = truth_table(2)
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = Or(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = Or(A, B, name="AB")
     formulae = [AB]
 
     for row in TT:
@@ -25,90 +35,76 @@ def test_upward():
         GT = np.logical_or(*list(map(fact_to_bool, row)))
 
         # load model and reason over facts
-        facts = {'A': row[0], 'B': row[1]}
+        facts = {"A": row[0], "B": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].upward()
+        model["AB"].upward()
 
         # evaluate the conjunction
-        prediction = model['AB'].state()
-        assert prediction is bool_to_fact(GT), (
-            f'And({row[0]}, {row[1]}) expected {GT}, received {prediction}')
+        prediction = model["AB"].state()
+        assert prediction is bool_to_fact(
+            GT
+        ), f"And({row[0]}, {row[1]}) expected {GT}, received {prediction}"
         model.flush()
 
 
 def test_downward():
     # define model rules
     model = Model()
-    model['A'] = Proposition('A')
-    model['B'] = Proposition('B')
-    model['AB'] = Or(model['A'], model['B'])
+    model["A"] = Proposition("A")
+    model["B"] = Proposition("B")
+    model["AB"] = Or(model["A"], model["B"])
 
     # define model facts
-    model.add_facts({
-        'A': FALSE,
-        'AB': TRUE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": FALSE, "AB": TRUE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is FALSE, (
-        f'Expected input A to be False, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is TRUE, (
-        f'Expected input B to be True, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is FALSE, f"Expected input A to be False, received {prediction}"
+    prediction = model["B"].state()
+    assert prediction is TRUE, f"Expected input B to be True, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'AB': FALSE
-    })
-    model['AB'].downward()
+    model.add_facts({"AB": FALSE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is FALSE, (
-        f'Expected input A to be False, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is FALSE, (
-        f'Expected input B to be False, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is FALSE, f"Expected input A to be False, received {prediction}"
+    prediction = model["B"].state()
+    assert prediction is FALSE, f"Expected input B to be False, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'AB': TRUE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": TRUE, "AB": TRUE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be TRUE, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is UNKNOWN, (
-        f'Expected input B to be UNKNOWN, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be TRUE, received {prediction}"
+    prediction = model["B"].state()
+    assert (
+        prediction is UNKNOWN
+    ), f"Expected input B to be UNKNOWN, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'AB': FALSE
-    })
-    model['AB'].downward()
+    model.add_facts({"A": TRUE, "AB": FALSE})
+    model["AB"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is CONTRADICTION, (
-        f'Expected input A to be CONTRADICTION, received {prediction}')
-    prediction = model['B'].state()
-    assert prediction is FALSE, (
-        f'Expected input B to be FALSE, received {prediction}')
+    prediction = model["A"].state()
+    assert (
+        prediction is CONTRADICTION
+    ), f"Expected input A to be CONTRADICTION, received {prediction}"
+    prediction = model["B"].state()
+    assert prediction is FALSE, f"Expected input B to be FALSE, received {prediction}"
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_bool_or_n.py
+++ b/tests/reasoning/logic/propositional/test_bool_or_n.py
@@ -14,8 +14,8 @@ def test_upward():
     n = 1000
     propositions = list()
     for i in range(1, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [Or(*propositions, name='Or_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [Or(*propositions, name="Or_n")]
 
     dat = np.random.random(n)
     row = list(map(lambda x: TRUE if x >= 0.5 else FALSE, dat))
@@ -29,47 +29,44 @@ def test_upward():
     # load model and reason over facts
     facts = {}
     for i in range(1, n):
-        facts['p' + str(i)] = row[i]
+        facts["p" + str(i)] = row[i]
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['Or_n'].upward()
+    model["Or_n"].upward()
 
     # evaluate the conjunction
-    prediction = model['Or_n'].state()
-    assert prediction is GT, (
-        f'Or({row}) expected {GT}, received {prediction}')
+    prediction = model["Or_n"].state()
+    assert prediction is GT, f"Or({row}) expected {GT}, received {prediction}"
     model.flush()
 
     # Test the case of all True
     for i in range(1, n):
-        facts['p' + str(i)] = TRUE
+        facts["p" + str(i)] = TRUE
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['Or_n'].upward()
+    model["Or_n"].upward()
 
     # evaluate the conjunction
-    prediction = model['Or_n'].state()
-    assert prediction is TRUE, (
-        f'Or({row}) expected {GT}, received {prediction}')
+    prediction = model["Or_n"].state()
+    assert prediction is TRUE, f"Or({row}) expected {GT}, received {prediction}"
     model.flush()
 
     # Test the case of all False
     for i in range(1, n):
-        facts['p' + str(i)] = FALSE
+        facts["p" + str(i)] = FALSE
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['Or_n'].upward()
+    model["Or_n"].upward()
 
     # evaluate the conjunction
-    prediction = model['Or_n'].state()
-    assert prediction is FALSE, (
-        f'Or({row}) expected {GT}, received {prediction}')
+    prediction = model["Or_n"].state()
+    assert prediction is FALSE, f"Or({row}) expected {GT}, received {prediction}"
     model.flush()
 
 
@@ -78,104 +75,88 @@ def test_downward():
     n = 1000
     propositions = list()
     for i in range(1, n):
-        propositions.append(Proposition('p' + str(i)))
+        propositions.append(Proposition("p" + str(i)))
 
     model = Model()
-    model['A'] = propositions[0]
-    for i in range(1, n-1):
-        model['P' + str(i)] = propositions[i]
-    model['Or_n'] = Or(*propositions)
+    model["A"] = propositions[0]
+    for i in range(1, n - 1):
+        model["P" + str(i)] = propositions[i]
+    model["Or_n"] = Or(*propositions)
 
     # define model facts
-    model.add_facts({
-        'A': FALSE,
-        'Or_n': FALSE
-    })
-    model['Or_n'].downward()
+    model.add_facts({"A": FALSE, "Or_n": FALSE})
+    model["Or_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is FALSE, (
-        f'Expected input A to be False, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is FALSE, f"Expected input A to be False, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is FALSE, (
-            f'Expected input to be False, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert prediction is FALSE, f"Expected input to be False, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'Or_n': TRUE
-    })
-    model['Or_n'].downward()
+    model.add_facts({"A": TRUE, "Or_n": TRUE})
+    model["Or_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be True, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be True, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is UNKNOWN, (
-            f'Expected input to be Unknown, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert (
+            prediction is UNKNOWN
+        ), f"Expected input to be Unknown, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': FALSE,
-        'Or_n': TRUE
-    })
-    model['Or_n'].downward()
+    model.add_facts({"A": FALSE, "Or_n": TRUE})
+    model["Or_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is FALSE, (
-        f'Expected input A to be False, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is FALSE, f"Expected input A to be False, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is UNKNOWN, (
-            f'Expected input to be Unknown, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert (
+            prediction is UNKNOWN
+        ), f"Expected input to be Unknown, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({
-        'A': TRUE,
-        'Or_n': FALSE
-    })
-    model['Or_n'].downward()
+    model.add_facts({"A": TRUE, "Or_n": FALSE})
+    model["Or_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is CONTRADICTION, (
-        f'Expected input A to be Contradiction, received {prediction}')
+    prediction = model["A"].state()
+    assert (
+        prediction is CONTRADICTION
+    ), f"Expected input A to be Contradiction, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is FALSE, (
-            f'Expected input to be False, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert prediction is FALSE, f"Expected input to be False, received {prediction}"
     model.flush()
 
     # test model facts for All False except one
-    model.add_facts({'P' + str(i): FALSE for i in range(1, n-1)})
-    model.add_facts({'Or_n': TRUE})
-    model['Or_n'].downward()
+    model.add_facts({"P" + str(i): FALSE for i in range(1, n - 1)})
+    model.add_facts({"Or_n": TRUE})
+    model["Or_n"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be True, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be True, received {prediction}"
 
-    for i in range(1, n-1):
-        prediction = model['P' + str(i)].state()
-        assert prediction is FALSE, (
-            f'Expected input to be False, received {prediction}')
+    for i in range(1, n - 1):
+        prediction = model["P" + str(i)].state()
+        assert prediction is FALSE, f"Expected input to be False, received {prediction}"
     model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_implies_lukasiewicz_1.py
+++ b/tests/reasoning/logic/propositional/test_implies_lukasiewicz_1.py
@@ -16,9 +16,9 @@ def test():
     x, y = np.meshgrid(steps, steps)
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = Implies(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = Implies(A, B, name="AB")
 
     # rules per model
     formulae = [AB]
@@ -32,7 +32,7 @@ def test():
             GT = 1 - a + b
 
             # facts per model
-            facts = {'A': (a, a), 'B': (b, b)}
+            facts = {"A": (a, a), "B": (b, b)}
 
             # load data into a new model
             model = Model()
@@ -40,14 +40,15 @@ def test():
             model.add_facts(facts)
 
             # evaluate the implication
-            model['AB'].upward()
+            model["AB"].upward()
 
             # test the prediction
-            prediction = model['AB'].get_facts()[0]
-            assert prediction - GT <= 1e-7, (
-                f'And({a}, {b}) expected {GT}, received {prediction}')
+            prediction = model["AB"].get_facts()[0]
+            assert (
+                prediction - GT <= 1e-7
+            ), f"And({a}, {b}) expected {GT}, received {prediction}"
             model.flush()
-    print('success')
+    print("success")
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/logic/propositional/test_inference_rules.py
+++ b/tests/reasoning/logic/propositional/test_inference_rules.py
@@ -7,8 +7,7 @@
 import os
 
 import pytest
-from lnn import (Model, Proposition, Implies, And, Or, Not, TRUE, FALSE,
-                 truth_table_dict)
+from lnn import Model, Proposition, Implies, And, Or, Not, TRUE, FALSE, truth_table_dict
 
 
 # https://en.wikipedia.org/wiki/List_of_rules_of_inference
@@ -21,19 +20,19 @@ def model():
 
 @pytest.fixture
 def p(model):
-    p = model['p'] = Proposition()
+    p = model["p"] = Proposition()
     return p
 
 
 @pytest.fixture
 def q(model):
-    q = model['q'] = Proposition()
+    q = model["q"] = Proposition()
     return q
 
 
 @pytest.fixture
 def r(model):
-    r = model['r'] = Proposition()
+    r = model["r"] = Proposition()
     return r
 
 
@@ -41,7 +40,7 @@ def assert_rule_for_truth_table(model, rule, variables):
     for test_case in truth_table_dict(*variables):
         model.add_facts(test_case)
         model.inference()
-        assert (rule.state() is TRUE)
+        assert rule.state() is TRUE
 
 
 def test_modus_ponens(model, p, q):
@@ -49,19 +48,16 @@ def test_modus_ponens(model, p, q):
     (p ∧ (p ➞ q)) ➞ q
     """
     # Downwards
-    p_implies_q = model['p_implies_q'] = Implies(p, q)
-    modus_ponens = model['modus_ponens'] = Implies(And(p, p_implies_q), q)
+    p_implies_q = model["p_implies_q"] = Implies(p, q)
+    modus_ponens = model["modus_ponens"] = Implies(And(p, p_implies_q), q)
 
-    model.add_facts({
-        p.name: TRUE,
-        p_implies_q.name: TRUE
-    })
+    model.add_facts({p.name: TRUE, p_implies_q.name: TRUE})
 
     model.inference()
-    assert (q.state() is TRUE)
+    assert q.state() is TRUE
 
     # Upwards
-    assert_rule_for_truth_table(model, modus_ponens, ['p', 'q'])
+    assert_rule_for_truth_table(model, modus_ponens, ["p", "q"])
 
 
 def test_modus_tolens(model, p, q):
@@ -69,33 +65,30 @@ def test_modus_tolens(model, p, q):
     (¬q ∧ (p ➞ q)) ➞ ¬p
     """
     # Downwards
-    not_q = model['not_q'] = Not(q)
-    p_implies_q = model['p_implies_q'] = Implies(p, q)
-    modus_tollens = model['modus_tollens'] = And(not_q, p_implies_q)
+    not_q = model["not_q"] = Not(q)
+    p_implies_q = model["p_implies_q"] = Implies(p, q)
+    modus_tollens = model["modus_tollens"] = And(not_q, p_implies_q)
 
-    model.add_facts({
-        q.name: FALSE,
-        p_implies_q.name: TRUE
-    })
+    model.add_facts({q.name: FALSE, p_implies_q.name: TRUE})
 
     model.inference()
-    assert (p.state() is FALSE)
+    assert p.state() is FALSE
 
     # Upwards
-    assert_rule_for_truth_table(model, modus_tollens, ['p', 'q'])
+    assert_rule_for_truth_table(model, modus_tollens, ["p", "q"])
 
 
 def test_associative(model, p, q, r):
     """
     ((p ∨ q) ∨ r) ➞ (p ∨ (q ∨ r))
     """
-    lhs = model['lhs'] = Or(Or(p, q), r)
-    rhs = model['rhs'] = Or(p, Or(q, r))
+    lhs = model["lhs"] = Or(Or(p, q), r)
+    rhs = model["rhs"] = Or(p, Or(q, r))
 
-    associative = model['associative'] = Implies(lhs, rhs)
+    associative = model["associative"] = Implies(lhs, rhs)
 
     # Upwards
-    assert_rule_for_truth_table(model, associative, ['p', 'q', 'r'])
+    assert_rule_for_truth_table(model, associative, ["p", "q", "r"])
 
 
 def test_commutative(model, p, q):
@@ -103,149 +96,152 @@ def test_commutative(model, p, q):
     (p ∧ q)  ➞ (q ∧ p)
     """
 
-    commutative = model['commutative'] = Implies(And(p, q), And(q, p))
+    commutative = model["commutative"] = Implies(And(p, q), And(q, p))
 
     # Upwards
-    assert_rule_for_truth_table(model, commutative, ['p', 'q'])
+    assert_rule_for_truth_table(model, commutative, ["p", "q"])
 
 
 def test_exportation(model, p, q, r):
     """
     ((p ∧ q)  ➞ r) ➞ (p ➞ (q ➞ r))
     """
-    exportation = model['exportation'] = \
-        Implies(Implies(And(p, q), r), Implies(p, Implies(q, r)))
+    exportation = model["exportation"] = Implies(
+        Implies(And(p, q), r), Implies(p, Implies(q, r))
+    )
 
     # Upwards
-    assert_rule_for_truth_table(model, exportation, ['p', 'q', 'r'])
+    assert_rule_for_truth_table(model, exportation, ["p", "q", "r"])
 
 
 def test_transposition(model, p, q):
     """
     (p ➞ q)  ➞ (¬q ➞ ¬p)
     """
-    transposition = model['transposition'] = \
-        Implies(Implies(p, q), Implies(Not(q), Not(p)))
+    transposition = model["transposition"] = Implies(
+        Implies(p, q), Implies(Not(q), Not(p))
+    )
 
     # Upwards
-    assert_rule_for_truth_table(model, transposition, ['p', 'q'])
+    assert_rule_for_truth_table(model, transposition, ["p", "q"])
 
 
 def test_hypothetical_syllogism(model, p, q, r):
     """
     ((p ➞ q) ∧ (q ➞ r)) ➞ (p ➞ r)
     """
-    hypothetical_syllogism = model['hypothetical_syllogism'] = \
-        Implies(And(Implies(p, q), Implies(q, r)), Implies(p, r))
+    hypothetical_syllogism = model["hypothetical_syllogism"] = Implies(
+        And(Implies(p, q), Implies(q, r)), Implies(p, r)
+    )
 
     # Upwards
-    assert_rule_for_truth_table(model, hypothetical_syllogism, ['p', 'q', 'r'])
+    assert_rule_for_truth_table(model, hypothetical_syllogism, ["p", "q", "r"])
 
 
 def test_material_implication(model, p, q):
     """
     (p ➞ q)  ➞ (¬p ∨ q)
     """
-    material_implication = model['material_implication'] = \
-        Implies(Implies(p, q), Or(Not(p), q))
+    material_implication = model["material_implication"] = Implies(
+        Implies(p, q), Or(Not(p), q)
+    )
 
     # Upwards
-    assert_rule_for_truth_table(model, material_implication, ['p', 'q'])
+    assert_rule_for_truth_table(model, material_implication, ["p", "q"])
 
 
 def test_distributive(model, p, q, r):
     """
-     ((p ∨ q) ∧ r) ➞ ((p ∧ r) ∨ (q ∧ r))
-     """
-    distributive = model['distributive'] = \
-        Implies(And(Or(p, q), r), Or(And(p, r), And(q, r)))
+    ((p ∨ q) ∧ r) ➞ ((p ∧ r) ∨ (q ∧ r))
+    """
+    distributive = model["distributive"] = Implies(
+        And(Or(p, q), r), Or(And(p, r), And(q, r))
+    )
 
     # Upwards
-    assert_rule_for_truth_table(model, distributive, ['p', 'q', 'r'])
+    assert_rule_for_truth_table(model, distributive, ["p", "q", "r"])
 
 
 def test_absorption(model, p, q):
     """
     (p ➞ q) ➞ (p ➞ (p ∧ q))
     """
-    absorption = model['absorption'] = \
-        Implies(Implies(p, q), Implies(p, And(p, q)))
+    absorption = model["absorption"] = Implies(Implies(p, q), Implies(p, And(p, q)))
 
     # Upwards
-    assert_rule_for_truth_table(model, absorption, ['p', 'q'])
+    assert_rule_for_truth_table(model, absorption, ["p", "q"])
 
 
 def test_disjunctive_syllogism(model, p, q):
     """
     ((p ∨ q) ∧ ¬p) ➞ q
     """
-    lhs = model['lhs'] = And(Or(p, q), Not(p))
-    disjunctive_syllogism = model['disjunctive_syllogism'] = Implies(lhs, q)
+    lhs = model["lhs"] = And(Or(p, q), Not(p))
+    disjunctive_syllogism = model["disjunctive_syllogism"] = Implies(lhs, q)
 
     # Downwards
     model.add_facts({lhs.name: TRUE})
     model.inference()
-    assert (q.state() is TRUE)
+    assert q.state() is TRUE
 
     model.flush()
     # Upwards
-    assert_rule_for_truth_table(model, disjunctive_syllogism, ['p', 'q'])
+    assert_rule_for_truth_table(model, disjunctive_syllogism, ["p", "q"])
 
 
 def test_addition(model, p, q):
     """
     p ➞ (p ∨ q)
     """
-    p_or_q = model['p_or_q'] = Or(p, q)
-    addition = model['addition'] = Implies(p, p_or_q)
+    p_or_q = model["p_or_q"] = Or(p, q)
+    addition = model["addition"] = Implies(p, p_or_q)
 
     # Downwards
-    model.add_facts({
-        p.name: TRUE,
-    })
+    model.add_facts(
+        {
+            p.name: TRUE,
+        }
+    )
     model.inference()
-    assert (p_or_q.state() is TRUE)
+    assert p_or_q.state() is TRUE
 
     model.flush()
     # Upwards
-    assert_rule_for_truth_table(model, addition, ['p', 'q'])
+    assert_rule_for_truth_table(model, addition, ["p", "q"])
 
 
 def test_simplification(model, p, q):
     """
     (p ∧ q) ➞ p
     """
-    p_and_q = model['p_and_q'] = And(p, q)
-    simplification = model['simplification'] = Implies(p_and_q, p)
+    p_and_q = model["p_and_q"] = And(p, q)
+    simplification = model["simplification"] = Implies(p_and_q, p)
 
     # Downwards
     model.add_facts({p_and_q.name: TRUE})
     model.inference()
-    assert (p.state() is TRUE)
+    assert p.state() is TRUE
 
     model.flush()
     # Upwards
-    assert_rule_for_truth_table(model, simplification, ['p', 'q'])
+    assert_rule_for_truth_table(model, simplification, ["p", "q"])
 
 
 def test_conjunction(model, p, q):
     """
     ((p) ∧ (q)) ➞ (p ∧ q)
     """
-    p_and_q = model['p_and_q'] = And(p, q)
-    conjunction = model['conjunction'] = Implies(p_and_q, And(p, q))
+    p_and_q = model["p_and_q"] = And(p, q)
+    conjunction = model["conjunction"] = Implies(p_and_q, And(p, q))
 
     # Downwards
-    model.add_facts({
-        p.name: TRUE,
-        q.name: TRUE
-    })
+    model.add_facts({p.name: TRUE, q.name: TRUE})
     model.inference()
-    assert (p_and_q.state() is TRUE)
+    assert p_and_q.state() is TRUE
 
     model.flush()
     # Upwards
-    assert_rule_for_truth_table(model, conjunction, ['p', 'q'])
+    assert_rule_for_truth_table(model, conjunction, ["p", "q"])
 
 
 def test_double_negation(model, p):
@@ -253,53 +249,55 @@ def test_double_negation(model, p):
     p ➞ (¬¬p)
     """
 
-    not_not_p = model['not_not_p'] = Not(Not(p))
-    double_negation = model['double_negation'] = Implies(p, not_not_p)
+    not_not_p = model["not_not_p"] = Not(Not(p))
+    double_negation = model["double_negation"] = Implies(p, not_not_p)
 
     # Downwards
-    model.add_facts({
-        p.name: TRUE,
-    })
+    model.add_facts(
+        {
+            p.name: TRUE,
+        }
+    )
     model.inference()
-    assert (not_not_p.state() is TRUE)
+    assert not_not_p.state() is TRUE
 
     model.flush()
     # Upwards
-    assert_rule_for_truth_table(model, double_negation, ['p'])
+    assert_rule_for_truth_table(model, double_negation, ["p"])
 
 
 def test_disjunctive_simplification(model, p):
     """
     (p ∨ p) ➞ p
     """
-    disjunctive_simplification = model['disjunctive_simplification'] = \
-        Implies(Or(p, p), p)
+    disjunctive_simplification = model["disjunctive_simplification"] = Implies(
+        Or(p, p), p
+    )
 
     # Upwards
-    assert_rule_for_truth_table(model, disjunctive_simplification, ['p'])
+    assert_rule_for_truth_table(model, disjunctive_simplification, ["p"])
 
 
 def test_resolution(model, p, q, r):
     """
     ((p ∨ q) ∧ (¬p ∨ r)) ➞ (q ∨ r)
     """
-    resolution = model['resolution'] = \
-        Implies(And(Or(p, q), Or(Not(p), r)), Or(q, r))
+    resolution = model["resolution"] = Implies(And(Or(p, q), Or(Not(p), r)), Or(q, r))
 
     # Upwards
-    assert_rule_for_truth_table(model, resolution, ['p', 'q', 'r'])
+    assert_rule_for_truth_table(model, resolution, ["p", "q", "r"])
 
 
 def test_disjunction_elimination(model, p, q, r):
     """
     ((p ➞ q) ∧ (r ➞ q) ∧ (p ∨ r)) ➞ q
     """
-    disjunction_elimination = model['disjunction_elimination'] = \
-        Implies(And(Implies(p, q), Implies(r, q), Or(p, r)), q)
+    disjunction_elimination = model["disjunction_elimination"] = Implies(
+        And(Implies(p, q), Implies(r, q), Or(p, r)), q
+    )
 
     # Upwards
-    assert_rule_for_truth_table(model, disjunction_elimination,
-                                ['p', 'q', 'r'])
+    assert_rule_for_truth_table(model, disjunction_elimination, ["p", "q", "r"])
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/logic/propositional/test_names.py
+++ b/tests/reasoning/logic/propositional/test_names.py
@@ -8,15 +8,15 @@ from lnn import Proposition, And, Model, TRUE
 
 
 def test():
-    for name in ['A^B', 'A∧B', 'A&B']:
+    for name in ["A^B", "A∧B", "A&B"]:
         """allow unicode characters in names"""
-        A = Proposition('A')
-        B = Proposition('B')
+        A = Proposition("A")
+        B = Proposition("B")
         AB = And(A, B, name=name)  # This name should be accepted
         assert AB is not None
 
         formulae = [AB]
-        facts = {'A': TRUE, 'B': TRUE}
+        facts = {"A": TRUE, "B": TRUE}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
@@ -28,4 +28,4 @@ def test():
 
 if __name__ == "__main__":
     test()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_not_1.py
+++ b/tests/reasoning/logic/propositional/test_not_1.py
@@ -12,12 +12,13 @@ def test_upward():
     inputs = [FALSE, TRUE, UNKNOWN]
     for i in range(3):
         model = Model()
-        model['not'] = Not(Proposition('A'))
-        model.add_facts({'A': inputs[i]})
-        model['not'].upward()
-        prediction = model['not'].state()
-        assert (prediction is GTs[i]), (
-            f'expected Not({inputs[i]}) = {GTs[i]}, received {prediction}')
+        model["not"] = Not(Proposition("A"))
+        model.add_facts({"A": inputs[i]})
+        model["not"].upward()
+        prediction = model["not"].state()
+        assert (
+            prediction is GTs[i]
+        ), f"expected Not({inputs[i]}) = {GTs[i]}, received {prediction}"
 
 
 def test_downward():
@@ -25,15 +26,16 @@ def test_downward():
     inputs = [FALSE, TRUE, UNKNOWN]
     for i in range(3):
         model = Model()
-        model['not'] = Not(Proposition('A'))
-        model.add_facts({'not': inputs[i]})
-        model['not'].downward()
-        prediction = model['A'].state()
-        assert (prediction is GTs[i]), (
-            f'expected Not({inputs[i]}) = {GTs[i]}, received A={prediction}')
+        model["not"] = Not(Proposition("A"))
+        model.add_facts({"not": inputs[i]})
+        model["not"].downward()
+        prediction = model["A"].state()
+        assert (
+            prediction is GTs[i]
+        ), f"expected Not({inputs[i]}) = {GTs[i]}, received A={prediction}"
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_or_lukasiewicz_1.py
+++ b/tests/reasoning/logic/propositional/test_or_lukasiewicz_1.py
@@ -16,9 +16,9 @@ def test():
     x, y = np.meshgrid(steps, steps)
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = Or(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = Or(A, B, name="AB")
 
     # rules per model
     formulae = [AB]
@@ -32,7 +32,7 @@ def test():
             GT = min(a + b, 1)
 
             # facts per model
-            facts = {'A': (a, a), 'B': (b, b)}
+            facts = {"A": (a, a), "B": (b, b)}
 
             # load data into a new model
             model = Model()
@@ -40,13 +40,14 @@ def test():
             model.add_facts(facts)
 
             # evaluate the disjunction
-            model['AB'].upward()
+            model["AB"].upward()
 
             # test the prediction
-            prediction = model['AB'].get_facts()[0]
-            assert prediction - GT <= 1e-7, (
-                f'And({a}, {b}) expected {GT}, received {prediction}')
-    print('success')
+            prediction = model["AB"].get_facts()[0]
+            assert (
+                prediction - GT <= 1e-7
+            ), f"And({a}, {b}) expected {GT}, received {prediction}"
+    print("success")
 
 
 if __name__ == "__main__":

--- a/tests/reasoning/logic/propositional/test_rv_and_n.py
+++ b/tests/reasoning/logic/propositional/test_rv_and_n.py
@@ -14,8 +14,8 @@ def test_upward():
     n = 1000
     propositions = list()
     for i in range(0, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [And(*propositions, name='And_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [And(*propositions, name="And_n")]
 
     dat = np.linspace(0.001, 1.0, n)
     GT = dat[0]
@@ -26,20 +26,22 @@ def test_upward():
     # load model and reason over facts
     facts = {}
     for i in range(0, n):
-        facts['p' + str(i)] = (dat[i], dat[i])
+        facts["p" + str(i)] = (dat[i], dat[i])
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['And_n'].upward()
+    model["And_n"].upward()
 
     # evaluate the conjunction
-    prediction = model['And_n'].get_facts()
-    assert prediction[0] == prediction[1], \
-        'Lower and upper bounds are not the same, ' + \
-        f'got {prediction[0]}, {prediction[1]}'
-    assert round(prediction[0].item(), 4) == round(GT, 4), (
-        f'And(...) failed, expected {GT}, received {prediction[0].item()}')
+    prediction = model["And_n"].get_facts()
+    assert prediction[0] == prediction[1], (
+        "Lower and upper bounds are not the same, "
+        + f"got {prediction[0]}, {prediction[1]}"
+    )
+    assert round(prediction[0].item(), 4) == round(
+        GT, 4
+    ), f"And(...) failed, expected {GT}, received {prediction[0].item()}"
     model.flush()
 
 
@@ -47,8 +49,8 @@ def test_downward():
     n = 1000
     propositions = list()
     for i in range(0, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [And(*propositions, name='And_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [And(*propositions, name="And_n")]
 
     dat = np.linspace(1.0, 1.0, n)
     GT = dat[0]
@@ -59,27 +61,27 @@ def test_downward():
     # load model and reason over facts
     facts = {}
     for i in range(0, n):
-        facts['p' + str(i)] = (dat[i], dat[i])
+        facts["p" + str(i)] = (dat[i], dat[i])
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['And_n'].upward()
+    model["And_n"].upward()
 
     # now make one of the inputs unknown
-    p0 = model['p0'].get_facts()
-    model.add_facts({
-        'p0': Fact.UNKNOWN
-    })
+    p0 = model["p0"].get_facts()
+    model.add_facts({"p0": Fact.UNKNOWN})
     model.downward()
 
     # evaluate the conjunction
-    prediction = model['p0'].get_facts()
-    assert prediction[0] == prediction[1], \
-        'Lower and upper bounds are not the same, ' + \
-        f'got {prediction[0]}, {prediction[1]}'
-    assert round(prediction[0].item(), 4) == round(p0[0].item(), 4), (
-        f'And(...) failed, expected {GT}, received {prediction[0].item()}')
+    prediction = model["p0"].get_facts()
+    assert prediction[0] == prediction[1], (
+        "Lower and upper bounds are not the same, "
+        + f"got {prediction[0]}, {prediction[1]}"
+    )
+    assert round(prediction[0].item(), 4) == round(
+        p0[0].item(), 4
+    ), f"And(...) failed, expected {GT}, received {prediction[0].item()}"
 
     # now make the AND false
     dat = np.linspace(0.0, 1.0, n)
@@ -87,27 +89,26 @@ def test_downward():
     # load model and reason over facts
     facts = {}
     for i in range(0, n):
-        facts['p' + str(i)] = (dat[i], dat[i])
+        facts["p" + str(i)] = (dat[i], dat[i])
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['And_n'].upward()
+    model["And_n"].upward()
 
     # now make one of the inputs unknown
-    p0 = model['p0'].get_facts()
-    model.add_facts({
-        'p0': Fact.UNKNOWN
-    })
+    p0 = model["p0"].get_facts()
+    model.add_facts({"p0": Fact.UNKNOWN})
     model.downward()
 
     # evaluate the conjunction
-    prediction = model['p0'].get_facts()
-    assert prediction[0].item() == 0 and prediction[1].item() == 1, \
-        "p0 should be UNKNOWN"
+    prediction = model["p0"].get_facts()
+    assert (
+        prediction[0].item() == 0 and prediction[1].item() == 1
+    ), "p0 should be UNKNOWN"
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_rv_or_n.py
+++ b/tests/reasoning/logic/propositional/test_rv_or_n.py
@@ -14,8 +14,8 @@ def test_upward():
     n = 1000
     propositions = list()
     for i in range(0, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [Or(*propositions, name='Or_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [Or(*propositions, name="Or_n")]
 
     dat = np.linspace(0.0001, 0.001, n)
     GT = dat[0]
@@ -26,20 +26,22 @@ def test_upward():
     # load model and reason over facts
     facts = {}
     for i in range(0, n):
-        facts['p' + str(i)] = (dat[i], dat[i])
+        facts["p" + str(i)] = (dat[i], dat[i])
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['Or_n'].upward()
+    model["Or_n"].upward()
 
     # evaluate the conjunction
-    prediction = model['Or_n'].get_facts()
-    assert prediction[0] == prediction[1], \
-        'Lower and upper bounds are not the same, ' + \
-        f'got {prediction[0]}, {prediction[1]}'
-    assert round(prediction[0].item(), 4) == round(GT, 4), (
-        f'Or(...) failed, expected {GT}, received {prediction[0].item()}')
+    prediction = model["Or_n"].get_facts()
+    assert prediction[0] == prediction[1], (
+        "Lower and upper bounds are not the same, "
+        + f"got {prediction[0]}, {prediction[1]}"
+    )
+    assert round(prediction[0].item(), 4) == round(
+        GT, 4
+    ), f"Or(...) failed, expected {GT}, received {prediction[0].item()}"
     model.flush()
 
 
@@ -47,8 +49,8 @@ def test_downward():
     n = 1000
     propositions = list()
     for i in range(0, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [Or(*propositions, name='Or_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [Or(*propositions, name="Or_n")]
 
     dat = np.linspace(0.0, 0.0, n)
     GT = dat[0]
@@ -59,27 +61,27 @@ def test_downward():
     # load model and reason over facts
     facts = {}
     for i in range(0, n):
-        facts['p' + str(i)] = (dat[i], dat[i])
+        facts["p" + str(i)] = (dat[i], dat[i])
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['Or_n'].upward()
+    model["Or_n"].upward()
 
     # now make one of the inputs unknown
-    p0 = model['p0'].get_facts()
-    model.add_facts({
-        'p0': Fact.UNKNOWN
-    })
+    p0 = model["p0"].get_facts()
+    model.add_facts({"p0": Fact.UNKNOWN})
     model.downward()
 
     # evaluate
-    prediction = model['p0'].get_facts()
-    assert prediction[0] == prediction[1], \
-        'Lower and upper bounds are not the same, ' + \
-        f'got {prediction[0]}, {prediction[1]}'
-    assert round(prediction[0].item(), 4) == round(p0[0].item(), 4), (
-        f'Or(...) failed, expected {GT}, received {prediction[0].item()}')
+    prediction = model["p0"].get_facts()
+    assert prediction[0] == prediction[1], (
+        "Lower and upper bounds are not the same, "
+        + f"got {prediction[0]}, {prediction[1]}"
+    )
+    assert round(prediction[0].item(), 4) == round(
+        p0[0].item(), 4
+    ), f"Or(...) failed, expected {GT}, received {prediction[0].item()}"
 
     # now make the OR True
     dat = np.linspace(0.0, 1.0, n)
@@ -87,27 +89,26 @@ def test_downward():
     # load model and reason over facts
     facts = {}
     for i in range(0, n):
-        facts['p' + str(i)] = (dat[i], dat[i])
+        facts["p" + str(i)] = (dat[i], dat[i])
 
     model = Model()
     model.add_formulae(*formulae)
     model.add_facts(facts)
-    model['Or_n'].upward()
+    model["Or_n"].upward()
 
     # now make one of the inputs unknown
-    p0 = model['p0'].get_facts()
-    model.add_facts({
-        'p0': Fact.UNKNOWN
-    })
+    p0 = model["p0"].get_facts()
+    model.add_facts({"p0": Fact.UNKNOWN})
     model.downward()
 
     # evaluate
-    prediction = model['p0'].get_facts()
-    assert prediction[0].item() == 0 and prediction[1].item() == 1, \
-        "p0 should be UNKNOWN"
+    prediction = model["p0"].get_facts()
+    assert (
+        prediction[0].item() == 0 and prediction[1].item() == 1
+    ), "p0 should be UNKNOWN"
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_simple.py
+++ b/tests/reasoning/logic/propositional/test_simple.py
@@ -4,9 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 ##
 
-from lnn import (Model, And, Or, Proposition,
-                 AXIOM, UPWARD, FALSE, TRUE,
-                 plot_params, plot_loss)
+from lnn import (
+    Model,
+    And,
+    Or,
+    Proposition,
+    AXIOM,
+    UPWARD,
+    FALSE,
+    TRUE,
+    plot_params,
+    plot_loss,
+)
 
 
 def test_1():
@@ -20,36 +29,31 @@ def test_1():
     model = Model()
 
     # rules
-    model['A'] = Proposition('A')
-    model['B'] = Proposition('B')
-    model['AB'] = And(model['A'], model['B'], world=AXIOM)
-    model['A|B'] = Or(model['A'], model['B'])
+    model["A"] = Proposition("A")
+    model["B"] = Proposition("B")
+    model["AB"] = And(model["A"], model["B"], world=AXIOM)
+    model["A|B"] = Or(model["A"], model["B"])
 
     # facts
-    model.add_facts({
-        'A': TRUE,
-        'B': FALSE
-    })
+    model.add_facts({"A": TRUE, "B": FALSE})
 
     # train/inference
-    losses = {
-        'contradiction': 1,
-        'logical': 1e-1}
+    losses = {"contradiction": 1, "logical": 1e-1}
     total_loss, _ = model.train(
         pbar=False,
         direction=UPWARD,
         losses=losses,
-        parameter_history={'weights': True, 'bias': True}
+        parameter_history={"weights": True, "bias": True},
     )
     model.print(params=True)
     plot_params(model)
     plot_loss(total_loss, losses)
 
-    A_and_B_weights = model['AB'].params('weights')
-    assert A_and_B_weights[1] <= .5, (
-        'expected input B to be downweighted <= .5, '
-        f'received {A_and_B_weights[1]}')
-    A_or_B_weights = model['A|B'].params('weights')
-    assert all(A_or_B_weights > .99), (
-        'expected weights at A or B to remain high, '
-        f'received {A_or_B_weights}')
+    A_and_B_weights = model["AB"].params("weights")
+    assert A_and_B_weights[1] <= 0.5, (
+        "expected input B to be downweighted <= .5, " f"received {A_and_B_weights[1]}"
+    )
+    A_or_B_weights = model["A|B"].params("weights")
+    assert all(A_or_B_weights > 0.99), (
+        "expected weights at A or B to remain high, " f"received {A_or_B_weights}"
+    )

--- a/tests/reasoning/logic/propositional/test_tri_and_1.py
+++ b/tests/reasoning/logic/propositional/test_tri_and_1.py
@@ -17,13 +17,13 @@ def test_upward():
         [FALSE, FALSE, FALSE],
         [UNKNOWN, TRUE, UNKNOWN],
         [UNKNOWN, UNKNOWN, UNKNOWN],
-        [UNKNOWN, FALSE, FALSE]
+        [UNKNOWN, FALSE, FALSE],
     ]
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = And(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = And(A, B, name="AB")
     formulae = [AB]
 
     for row in TT:
@@ -31,16 +31,17 @@ def test_upward():
         GT = row[2]
 
         # load model and reason over facts
-        facts = {'A': row[0], 'B': row[1]}
+        facts = {"A": row[0], "B": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].upward()
+        model["AB"].upward()
 
         # evaluate the conjunction
-        prediction = model['AB'].state()
-        assert prediction is GT, (
-            f'And({row[0]}, {row[1]}) expected {GT}, received {prediction}')
+        prediction = model["AB"].state()
+        assert (
+            prediction is GT
+        ), f"And({row[0]}, {row[1]}) expected {GT}, received {prediction}"
         model.flush()
 
 
@@ -56,31 +57,33 @@ def test_downward():
     ]
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = And(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = And(A, B, name="AB")
     formulae = [AB]
 
     for i, row in enumerate(TT):
         # load model and reason over facts
-        facts = {'B': row[0], 'AB': row[1]}
+        facts = {"B": row[0], "AB": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].downward(index=0)
+        model["AB"].downward(index=0)
 
         # evaluate the conjunction
-        prediction = model['A'].state()
-        assert prediction is row[2], (
-            f'{i} And{row} Expected {row[2]}, received {prediction}')
+        prediction = model["A"].state()
+        assert (
+            prediction is row[2]
+        ), f"{i} And{row} Expected {row[2]}, received {prediction}"
 
-        prediction = model['B'].state()
-        assert prediction is row[0], (
-            f'{i} And{row} Expected {row[0]}, received {prediction}')
+        prediction = model["B"].state()
+        assert (
+            prediction is row[0]
+        ), f"{i} And{row} Expected {row[0]}, received {prediction}"
         model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_tri_and_n.py
+++ b/tests/reasoning/logic/propositional/test_tri_and_n.py
@@ -17,15 +17,15 @@ def test_upward():
         [FALSE, FALSE, FALSE],
         [UNKNOWN, TRUE, UNKNOWN],
         [UNKNOWN, UNKNOWN, UNKNOWN],
-        [UNKNOWN, FALSE, FALSE]
+        [UNKNOWN, FALSE, FALSE],
     ]
 
     # define the rules
     n = 1000
     propositions = list()
     for i in range(1, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [And(*propositions, name='And_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [And(*propositions, name="And_n")]
 
     for row in TT:
         # get ground truth
@@ -33,18 +33,19 @@ def test_upward():
 
         # load model and reason over facts
         facts = {}
-        facts['p1'] = row[0]
+        facts["p1"] = row[0]
         for i in range(2, n):
-            facts['p' + str(i)] = row[1]
+            facts["p" + str(i)] = row[1]
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['And_n'].upward()
+        model["And_n"].upward()
 
         # evaluate the conjunction
-        prediction = model['And_n'].state()
-        assert prediction is GT, (
-            f'And({row[0]}, {row[1]}...) expected {GT}, received {prediction}')
+        prediction = model["And_n"].state()
+        assert (
+            prediction is GT
+        ), f"And({row[0]}, {row[1]}...) expected {GT}, received {prediction}"
         model.flush()
 
 
@@ -63,8 +64,8 @@ def test_downward():
     n = 1000
     propositions = list()
     for i in range(1, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [And(*propositions, name='And_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [And(*propositions, name="And_n")]
 
     for row in TT:
         # get ground truth
@@ -72,23 +73,24 @@ def test_downward():
 
         # load model and reason over facts
         facts = {}
-        facts['And_n'] = row[1]
+        facts["And_n"] = row[1]
         for i in range(2, n):
-            facts['p' + str(i)] = row[0]
+            facts["p" + str(i)] = row[0]
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['And_n'].downward(index=0)
+        model["And_n"].downward(index=0)
 
         # evaluate the conjunction
-        prediction = model['p1'].state()
+        prediction = model["p1"].state()
         assert prediction is GT, (
-            f'And(A, {row[0]}, ...)={row[1]} expected' +
-            ' A={GT}, received {prediction}')
+            f"And(A, {row[0]}, ...)={row[1]} expected"
+            + " A={GT}, received {prediction}"
+        )
         model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_tri_implies_1.py
+++ b/tests/reasoning/logic/propositional/test_tri_implies_1.py
@@ -18,13 +18,13 @@ def test_upward():
         [FALSE, FALSE, TRUE],
         [UNKNOWN, TRUE, TRUE],
         [UNKNOWN, UNKNOWN, UNKNOWN],
-        [UNKNOWN, FALSE, UNKNOWN]
+        [UNKNOWN, FALSE, UNKNOWN],
     ]
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = Implies(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = Implies(A, B, name="AB")
     formulae = [AB]
 
     for row in TT:
@@ -32,16 +32,17 @@ def test_upward():
         GT = row[2]
 
         # load model and reason over facts
-        facts = {'A': row[0], 'B': row[1]}
+        facts = {"A": row[0], "B": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].upward()
+        model["AB"].upward()
 
         # evaluate the conjunction
-        prediction = model['AB'].state()
-        assert prediction == GT, (
-            f'And({row[0]}, {row[1]}) expected {GT}, received {prediction}')
+        prediction = model["AB"].state()
+        assert (
+            prediction == GT
+        ), f"And({row[0]}, {row[1]}) expected {GT}, received {prediction}"
         model.flush()
 
 
@@ -57,9 +58,9 @@ def test_downward():
     ]
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = Implies(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = Implies(A, B, name="AB")
     formulae = [AB]
 
     for i, row in enumerate(TT):
@@ -67,20 +68,19 @@ def test_downward():
         GT = row[2]
 
         # load model and reason over facts
-        facts = {'B': row[0], 'AB': row[1]}
+        facts = {"B": row[0], "AB": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].downward(index=0)
+        model["AB"].downward(index=0)
 
         # evaluate the conjunction
-        prediction = model['A'].state()
-        assert prediction is GT, (
-            f'{i}: Expected {GT}, received {prediction}')
+        prediction = model["A"].state()
+        assert prediction is GT, f"{i}: Expected {GT}, received {prediction}"
         model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_tri_not_1.py
+++ b/tests/reasoning/logic/propositional/test_tri_not_1.py
@@ -14,19 +14,19 @@ def test_upward():
         # A, Not(A)
         [TRUE, FALSE],
         [FALSE, TRUE],
-        [UNKNOWN, UNKNOWN]
+        [UNKNOWN, UNKNOWN],
     ]
 
     # define the rules
-    A = Proposition('A')
+    A = Proposition("A")
 
     try:
-        NotA = Not(A, A, name='NotA')
+        NotA = Not(A, A, name="NotA")
         assert False, "Not should not accept multiple inputs"
     except TypeError:
         pass
 
-    NotA = Not(A, name='NotA')
+    NotA = Not(A, name="NotA")
     formulae = [NotA]
 
     for row in TT:
@@ -34,57 +34,57 @@ def test_upward():
         GT = fact_to_bool(row[1])
 
         # load model and reason over facts
-        facts = {'A': row[0]}
+        facts = {"A": row[0]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['NotA'].upward()
+        model["NotA"].upward()
 
         # evaluate the conjunction
-        prediction = model['NotA'].state(to_bool=True)
-        assert prediction is GT, (
-            f'Not({row[0]}, {row[1]}) expected {GT}, received {prediction}')
+        prediction = model["NotA"].state(to_bool=True)
+        assert (
+            prediction is GT
+        ), f"Not({row[0]}, {row[1]}) expected {GT}, received {prediction}"
         model.flush()
 
 
 def test_downward():
     # define model rules
     model = Model()
-    model['A'] = Proposition('A')
-    model['NotA'] = Not(model['A'])
+    model["A"] = Proposition("A")
+    model["NotA"] = Not(model["A"])
 
     # define model facts
-    model.add_facts({'NotA': TRUE})
-    model['NotA'].downward()
+    model.add_facts({"NotA": TRUE})
+    model["NotA"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is FALSE, (
-        f'Expected input A to be False, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is FALSE, f"Expected input A to be False, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({'NotA': FALSE})
-    model['NotA'].downward()
+    model.add_facts({"NotA": FALSE})
+    model["NotA"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is TRUE, (
-        f'Expected input A to be True, received {prediction}')
+    prediction = model["A"].state()
+    assert prediction is TRUE, f"Expected input A to be True, received {prediction}"
     model.flush()
 
     # define model facts
-    model.add_facts({'NotA': UNKNOWN})
-    model['NotA'].downward()
+    model.add_facts({"NotA": UNKNOWN})
+    model["NotA"].downward()
 
     # evaluate
-    prediction = model['A'].state()
-    assert prediction is UNKNOWN, (
-        f'Expected input A to be Unknown, received {prediction}')
+    prediction = model["A"].state()
+    assert (
+        prediction is UNKNOWN
+    ), f"Expected input A to be Unknown, received {prediction}"
     model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_tri_or_1.py
+++ b/tests/reasoning/logic/propositional/test_tri_or_1.py
@@ -17,13 +17,13 @@ def test_upward():
         [FALSE, FALSE, FALSE],
         [UNKNOWN, TRUE, TRUE],
         [UNKNOWN, UNKNOWN, UNKNOWN],
-        [UNKNOWN, FALSE, UNKNOWN]
+        [UNKNOWN, FALSE, UNKNOWN],
     ]
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = Or(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = Or(A, B, name="AB")
     formulae = [AB]
 
     for i, row in enumerate(TT):
@@ -31,16 +31,17 @@ def test_upward():
         GT = row[2]
 
         # load model and reason over facts
-        facts = {'A': row[0], 'B': row[1]}
+        facts = {"A": row[0], "B": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].upward()
+        model["AB"].upward()
 
         # evaluate the conjunction
-        prediction = model['AB'].state()
-        assert prediction is GT, (
-            f'{i} Or({row[0]}, {row[1]}) expected {GT}, received {prediction}')
+        prediction = model["AB"].state()
+        assert (
+            prediction is GT
+        ), f"{i} Or({row[0]}, {row[1]}) expected {GT}, received {prediction}"
         model.flush()
 
 
@@ -50,40 +51,42 @@ def test_downward():
         [FALSE, FALSE, FALSE],
         [FALSE, UNKNOWN, UNKNOWN],
         [FALSE, TRUE, TRUE],
-        [TRUE, FALSE, FALSE],      # contradiction at B
+        [TRUE, FALSE, FALSE],  # contradiction at B
         [TRUE, UNKNOWN, UNKNOWN],  # contradiction at Or()
         [TRUE, TRUE, UNKNOWN],
     ]
 
     # define the rules
-    A = Proposition('A')
-    B = Proposition('B')
-    AB = Or(A, B, name='AB')
+    A = Proposition("A")
+    B = Proposition("B")
+    AB = Or(A, B, name="AB")
     formulae = [AB]
 
     for i, row in enumerate(TT):
         # load model and reason over facts
-        facts = {'B': row[0], 'AB': row[1]}
+        facts = {"B": row[0], "AB": row[1]}
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['AB'].downward(index=0)
+        model["AB"].downward(index=0)
 
         # evaluate the conjunction
-        prediction = model['A'].state()
+        prediction = model["A"].state()
         assert prediction is row[2], (
-            f'{i}: Or(A, {row[0]}) = {row[1]}, Expected A={row[2]}, '
-            f'received {prediction}')
+            f"{i}: Or(A, {row[0]}) = {row[1]}, Expected A={row[2]}, "
+            f"received {prediction}"
+        )
 
         # evaluate the conjunction
-        prediction = model['B'].state()
+        prediction = model["B"].state()
         assert prediction is row[0], (
-            f'{i}: Or(A, {row[0]}) = {row[1]}, Expected B={row[0]}, '
-            f'received {prediction}')
+            f"{i}: Or(A, {row[0]}) = {row[1]}, Expected B={row[0]}, "
+            f"received {prediction}"
+        )
         model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_tri_or_n.py
+++ b/tests/reasoning/logic/propositional/test_tri_or_n.py
@@ -17,33 +17,34 @@ def test_upward():
         [FALSE, FALSE, FALSE],
         [UNKNOWN, TRUE, TRUE],
         [UNKNOWN, UNKNOWN, UNKNOWN],
-        [UNKNOWN, FALSE, UNKNOWN]
+        [UNKNOWN, FALSE, UNKNOWN],
     ]
 
     # define the rules
     n = 1000
     propositions = list()
     for i in range(1, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [Or(*propositions, name='Or_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [Or(*propositions, name="Or_n")]
 
     for row in TT:
         # get ground truth
         GT = row[2]
 
         # load model and reason over facts
-        facts = {'p1': row[0]}
+        facts = {"p1": row[0]}
         for i in range(2, n):
-            facts['p' + str(i)] = row[1]
+            facts["p" + str(i)] = row[1]
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['Or_n'].upward()
+        model["Or_n"].upward()
 
         # evaluate the conjunction
-        prediction = model['Or_n'].state()
-        assert prediction is GT, (
-            f'Or({row[0]}, {row[1]}...) expected {GT}, received {prediction}')
+        prediction = model["Or_n"].state()
+        assert (
+            prediction is GT
+        ), f"Or({row[0]}, {row[1]}...) expected {GT}, received {prediction}"
         model.flush()
 
 
@@ -53,7 +54,7 @@ def test_downward():
         [FALSE, FALSE, FALSE],
         [FALSE, UNKNOWN, UNKNOWN],
         [FALSE, TRUE, TRUE],
-        [TRUE, FALSE, FALSE],      # contradiction at B
+        [TRUE, FALSE, FALSE],  # contradiction at B
         [TRUE, UNKNOWN, UNKNOWN],  # contradiction at Or()
         [TRUE, TRUE, UNKNOWN],
     ]
@@ -62,31 +63,31 @@ def test_downward():
     n = 1000
     propositions = list()
     for i in range(1, n):
-        propositions.append(Proposition('p' + str(i)))
-    formulae = [Or(*propositions, name='Or_n')]
+        propositions.append(Proposition("p" + str(i)))
+    formulae = [Or(*propositions, name="Or_n")]
 
     for row in TT:
         # get ground truth
         GT = row[2]
 
         # load model and reason over facts
-        facts = {'Or_n': row[1]}
+        facts = {"Or_n": row[1]}
         for i in range(2, n):
-            facts['p' + str(i)] = row[0]
+            facts["p" + str(i)] = row[0]
         model = Model()
         model.add_formulae(*formulae)
         model.add_facts(facts)
-        model['Or_n'].downward(index=0)
+        model["Or_n"].downward(index=0)
 
         # evaluate the conjunction
-        prediction = model['p1'].state()
+        prediction = model["p1"].state()
         assert prediction is GT, (
-            f'Or(A, {row[0]}, ...)={row[1]} expected A={GT}, ' +
-            'received {prediction}')
+            f"Or(A, {row[0]}, ...)={row[1]} expected A={GT}, " + "received {prediction}"
+        )
         model.flush()
 
 
 if __name__ == "__main__":
     test_upward()
     test_downward()
-    print('success')
+    print("success")

--- a/tests/reasoning/logic/propositional/test_unpacking_propositions.py
+++ b/tests/reasoning/logic/propositional/test_unpacking_propositions.py
@@ -9,8 +9,8 @@ from lnn import Proposition, Model
 
 def test():
     model = Model()
-    model['Smokes'] = Proposition()
-    model['Friends'] = Proposition()
+    model["Smokes"] = Proposition()
+    model["Friends"] = Proposition()
 
     smokes, friends = model.nodes.values()
     assert smokes.name == "Smokes", "Didn't get smokes proposition"


### PR DESCRIPTION
Hi,

following PR includes:
- reformatted whole project to [Black formatter style](https://black.readthedocs.io/en/stable/index.html)
- `README.md` badge
- Github action to lint every commit/push if is Black formatted

Only place where I am little bit worried are the `__init__.py` files, [original code](https://github.com/IBM/LNN/blob/818452a30ba233b5bfa1d7eab6f3d1053a38a35b/lnn/__init__.py#L50) was separated by blank lines for better readability of `__all__` variable. Not sure if constants like `UPWARD` should be exposed in this way, maybe exposing only `Direction` and access `UPWARD` as `Direction.UPWARD`? Is already done on multiple [places in the project](https://github.com/IBM/LNN/blob/c591de211c435d0e63942bcfff111ea32b1459c1/lnn/model.py#L293).

If readibility is the issue, lines can be separated by commets:

```python
__all__ = [
	CONSTANT,
# comment
	CONSTANT2
]
```

Feel free to finish other modifications and reformat project by yourself (since merging of this PR can be problematic). If you run Black on the other branches, merge should be quite straightforward.

```bash
cd LNN
black .
```