### PR TITLE
Graph plot with node type labels

### DIFF
--- a/lnn/utils.py
+++ b/lnn/utils.py
@@ -77,16 +77,21 @@ def predicate_truth_table(*args: str, arity: int, model, states=None):
 
 
 def plot_graph(self, **kwds) -> None:
+    labels = {node: f"{node.__class__.__name__}\n{node}" for node in self.graph}
+
     options = {
         'with_labels': True,
         'arrows': True,
         'edge_color': '#d0e2ff',
         'node_size': 1,
         'font_size': 9,
+        'labels': labels
     }
+
     options.update(kwds)
     pos = nx.drawing.nx_agraph.graphviz_layout(self.graph, prog='dot')
     nx.draw(self.graph, pos, **options)
+
     plt.show()
 
 


### PR DESCRIPTION
Simple modification to include node type in the graph plot.

Demo:
```python
import networkx as nx
import matplotlib.pyplot as plt

from lnn import Predicate, Variable, Exists, Implies, ForAll, Model, World
from lnn.utils import plot_graph

model = Model()

x = Variable("x")

square = Predicate(name="square")
rectangle = Predicate(name="rectangle")
foursides = Predicate(name="foursides")

square_rect = ForAll(
    x,
    Implies(square(x), rectangle(x), name="square-rect"),
    name="all-square-rect",
    world=World.AXIOM,
)
rect_foursides = ForAll(
    x,
    Implies(rectangle(x), foursides(x), name="rect-foursides"),
    name="all-rect-foursides",
    world=World.AXIOM,
)

query = Exists(x, foursides(x), name="foursided_objects")

model.add_formulae(square, rectangle, square_rect, rect_foursides, query)

plot_graph(model)
```

Output:
![output](https://user-images.githubusercontent.com/510112/154858254-65110555-11a1-4249-9e44-57185b6663b2.png)

