### PR TITLE
Throws exception when Predicate is not called

### DIFF
--- a/lnn/symbolic/logic.py
+++ b/lnn/symbolic/logic.py
@@ -149,6 +149,13 @@ class _Formula:
         world: World = World.OPEN,
         **kwds,
     ):
+        # check if all subformula has called predicates
+        if formula:
+            for subformula in formula:
+                if isinstance(subformula, Predicate):
+                    raise ValueError(
+                        f"predicate {subformula} inside formula must be called"
+                    )
 
         # formula naming
         self.name = (

--- a/tests/general/test_predicate.py
+++ b/tests/general/test_predicate.py
@@ -1,0 +1,23 @@
+##
+# Copyright 2021 IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+##
+
+import pytest
+
+from lnn import Predicate, And, Or, Implies, Bidirectional
+
+
+@pytest.mark.parametrize("CompoundFormulae", [And, Or, Implies, Bidirectional])
+def test_predicate_called(CompoundFormulae):
+    P = Predicate("P", arity=0)
+
+    with pytest.raises(ValueError):
+        CompoundFormulae(P, P())
+
+    with pytest.raises(ValueError):
+        CompoundFormulae(P(), P)
+
+    with pytest.raises(ValueError):
+        CompoundFormulae(P, P)


### PR DESCRIPTION
```python
In [1]: from lnn import Predicate, And
   ...: 
   ...: P = Predicate("P", arity=0)
   ...: 

In [2]: And(P(), P())
Out[2]: <lnn.symbolic.logic.And at 0x1107e4d30>

In [3]: And(P(), P)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [3], in <module>
----> 1 And(P(), P)

File ~/Gits/LNN/lnn/symbolic/logic.py:1110, in _NAryNeuron.__init__(self, *formula, **kwds)
   1109 def __init__(self, *formula, **kwds):
-> 1110     super().__init__(*formula, arity=len(formula), **kwds)

File ~/Gits/LNN/lnn/symbolic/logic.py:976, in _ConnectiveNeuron.__init__(self, *formula, **kwds)
    975 def __init__(self, *formula, **kwds):
--> 976     super().__init__(*formula, **kwds)
    977     self.neuron = _NeuralActivation(kwds.get("neuron", {}).get("type"))(
    978         self.propositional, self.arity, self.world, **kwds.get("neuron", {})
    979     )
    980     self.func = self.neuron.function(
    981         self.__class__.__name__, direction=Direction.UPWARD
    982     )

File ~/Gits/LNN/lnn/symbolic/logic.py:971, in _ConnectiveFormula.__init__(self, *formula, **kwds)
    970 def __init__(self, *formula: _Formula, **kwds):
--> 971     super().__init__(*formula, **kwds)

File ~/Gits/LNN/lnn/symbolic/logic.py:156, in _Formula.__init__(self, name, arity, world, *formula, **kwds)
    154     for subformula in formula:
    155         if isinstance(subformula, Predicate):
--> 156             raise ValueError(
    157                 f"predicate {subformula} inside formula must be called"
    158             )
    160 # formula naming
    161 self.name = (
    162     name
    163     if name
    164     else (f"{self.class_name}_{_Formula.unique_num[self.class_name]}")
    165 )

ValueError: predicate P inside formula must be called
```