### PR TITLE
CI tests migrated to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.10"
+            args: ""
+            os: ubuntu-latest
+          - python-version: 3.9
+            args: ""
+            os: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz graphviz-dev
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install dependencies
+        run: pip install -e .[test]
+      - name: Run tests with ${{ matrix.args }}
+        run: pytest ${{ matrix.args }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://app.travis-ci.com/IBM/LNN.svg?branch=master)](https://app.travis-ci.com/IBM/LNN)
+[![Build Status](https://github.com/IBM/LNN/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/IBM/LNN/actions/workflows/build.yml?query=branch%3Amaster)
 [![License](https://img.shields.io/github/license/IBM/LNN)](https://github.com/IBM/LNN/blob/master/LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 

--- a/setup.py
+++ b/setup.py
@@ -5,23 +5,19 @@
 ##
 
 import setuptools
+import pathlib
 
-with open("README.md", "r") as f:
-    long_description = f.read()
-
-with open("requirements.txt", "r") as f:
-    install_requires = f.read().replace("==", ">=")
 
 setuptools.setup(
     name="lnn",
     version="1.0",
     author="IBM Research",
     description="A `Neuro = Symbolic` framework for weighted " "real-valued logic",
-    long_description=long_description,
+    long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
     url="https://github.com/IBM/LNN",
     packages=setuptools.find_packages(),
-    install_requires=install_requires,
+    install_requires=pathlib.Path("requirements.txt").read_text().replace("==", ">="),
     extras_require={
         "test": ["pytest"],
     },
@@ -31,5 +27,3 @@ setuptools.setup(
     ],
     python_requires=">=3.9",
 )
-
-print(setuptools)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setuptools.setup(
     url="https://github.com/IBM/LNN",
     packages=setuptools.find_packages(),
     install_requires=install_requires,
+    extras_require={
+        "test": ["pytest"],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Migrated Travis CI to Github Actions (`build.yml`, currently running on python 3.8 and 3.9 in parallel). Simplified `setup.py` and new badge in `README.md` (badge will work after merge since is pointed to master branch of main repo).