### PR TITLE
Disable output of test when is not called directly

### DIFF
--- a/tests/learning/fol/test_bool_and_1.py
+++ b/tests/learning/fol/test_bool_and_1.py
@@ -42,7 +42,7 @@ def test():
     total_loss, _ = model.train(
         direction=UPWARD, losses=losses, parameter_history=parameter_history
     )
-    model.print(params=True)
+
     predictions = model[p1.name].state().values()
     assert all([fact is TRUE for fact in predictions]), (
         "expected AB Facts to all be TRUE, received bounds "
@@ -54,5 +54,6 @@ def test():
 
 if __name__ == "__main__":
     model, total_loss, losses = test()
+    model.print(params=True)
     plot_loss(total_loss, losses)
     plot_params(model)

--- a/tests/learning/fol/test_bool_and_supervised_1.py
+++ b/tests/learning/fol/test_bool_and_supervised_1.py
@@ -49,7 +49,7 @@ def test():
     total_loss, _ = model.train(
         direction=UPWARD, losses=losses, parameter_history=parameter_history
     )
-    model.print(params=True)
+
     predictions = model[p1.name].state().values()
     assert all([fact is TRUE for fact in predictions]), (
         "expected AB Facts to all be TRUE, received bounds "
@@ -60,6 +60,7 @@ def test():
 
 
 if __name__ == "__main__":
-    my_model, total_loss, losses = test()
+    model, total_loss, losses = test()
+    model.print(params=True)
     plot_loss(total_loss, losses)
-    plot_params(my_model)
+    plot_params(model)

--- a/tests/learning/fol/test_supervised_family_tree.py
+++ b/tests/learning/fol/test_supervised_family_tree.py
@@ -263,7 +263,7 @@ def test_2():
         )
 
 
-def test_3():
+def test_3(output=False):
     """
     In this test all positive examples are provided and the rest are assumed
     negative.
@@ -389,7 +389,9 @@ def test_3():
                 subrule_and_vars = subrule_and.binding_str
                 chosen_idx.append(subrule_and_vars)
 
-        rule.print(params=True)
+        if output:
+            rule.print(params=True)
+
         num_chosen = len(chosen_idx)
         assert num_chosen == 1, f"expected 1 got {num_chosen} in {chosen_idx}"
         assert chosen_idx[0] == target[1], (
@@ -405,5 +407,5 @@ def test_3():
 if __name__ == "__main__":
     test_1()
     test_2()
-    test_3()
+    test_3(output=True)
     print("success")

--- a/tests/learning/lifted/grecian_1.py
+++ b/tests/learning/lifted/grecian_1.py
@@ -27,8 +27,6 @@ def test():
 
     # perform inference/learning on the model
     model.infer(lifted=True)
-    model.print()
-    plot_graph(model)
 
     GT = ["(G → M)", "(H → (L ∨ A))", "(G → (L ∨ A))"]
     for gt in GT:
@@ -36,7 +34,11 @@ def test():
             gt in model.nodes.keys()
         ), f"lifted preprocessing could not find {gt} in the model"
 
+    return model
+
 
 if __name__ == "__main__":
-    test()
+    model = test()
+    model.print()
+    plot_graph(model)
     print("success")

--- a/tests/learning/propositional/test_bidirectional_1.py
+++ b/tests/learning/propositional/test_bidirectional_1.py
@@ -7,7 +7,7 @@
 from lnn import Model, truth_table
 
 
-def test_1():
+def test_1(output=False):
     """decrease weights for contradictory facts
 
     given And(A, B) - reduce the weight on B
@@ -25,5 +25,11 @@ def test_1():
             }
         )
         model.upward()
-        model[AB.name].print()
+        if output:
+            model[AB.name].print()
         model.flush()
+
+
+if __name__ == "__main__":
+    test_1(output=True)
+    print("success")

--- a/tests/learning/propositional/test_bool_and_1.py
+++ b/tests/learning/propositional/test_bool_and_1.py
@@ -28,7 +28,6 @@ def test_1():
 
     # train/inference
     model.train(direction=UPWARD, losses={"contradiction": 1})
-    model.print(params=True)
 
     weights = model["AB"].params("weights")
     bounds = model["B"].state()
@@ -36,6 +35,8 @@ def test_1():
         weights[1] <= 1 / 2
     ), f"expected input B to be downweighted <= 0., received {weights[1]}"
     assert bounds is FALSE, f"expected bounds to remain False, received {bounds}"
+
+    return model
 
 
 def test_2():
@@ -90,7 +91,7 @@ def test_3():
     assert bounds is FALSE, f"expected bounds to remain False, received {bounds}"
 
 
-def test_multiple():
+def test_multiple(output=False):
     """decrease weights for contradictory facts
 
     given And(n inputs) - reduce the weight on r random
@@ -116,7 +117,9 @@ def test_multiple():
             *[model[f"{p}"] for p in prop], world=World.AXIOM, neuron=neuron
         )
         model.train(losses=["contradiction"], learning_rate=1e-1)
-        model.print(params=True)
+
+        if output:
+            model.print(params=True)
 
         # test operator bounds
         prediction = model["and"].state()
@@ -178,10 +181,11 @@ def test_all():
 
 
 if __name__ == "__main__":
-    test_1()
+    model = test_1()
+    model.print(params=True)
     test_2()
     test_3()
-    test_multiple()
+    test_multiple(output=True)
     test_bias()
     test_all()
     print("success")

--- a/tests/learning/propositional/test_bool_implies_1.py
+++ b/tests/learning/propositional/test_bool_implies_1.py
@@ -28,11 +28,12 @@ def test_true_operator():
     model["AB"] = Implies(model["LHS"], model["RHS"], world=World.AXIOM)
     model.add_facts({"LHS": TRUE, "RHS": FALSE})
     model.train(direction=UPWARD, losses=["contradiction"])
-    model.print(params=True)
     bias = model["AB"].params("bias")
     bounds = model["AB"].state()
     assert bias <= 1e-5, f"expected bias to be downweighted <= 0., received {bias}"
     assert bounds is TRUE, f"expected operator bounds to remain True, received {bounds}"
+
+    return model
 
 
 def test_false_operator_1():
@@ -105,7 +106,8 @@ def test_false_operator_3():
 
 
 if __name__ == "__main__":
-    test_true_operator()
+    model = test_true_operator()
+    model.print(params=True)
     test_false_operator_1()
     test_false_operator_2()
     test_false_operator_3()

--- a/tests/learning/propositional/test_logical_1.py
+++ b/tests/learning/propositional/test_logical_1.py
@@ -23,12 +23,13 @@ def test_1():
     total_loss, _ = model.train(
         losses=losses, learning_rate=0.1, parameter_history=parameter_history
     )
-    model.print(params=True)
+
     return total_loss, losses, model
 
 
 if __name__ == "__main__":
     total_loss, losses, model = test_1()
+    model.print(params=True)
     plot_loss(total_loss, losses)
     plot_params(model)
     print("success")

--- a/tests/learning/propositional/test_simple_graph_1.py
+++ b/tests/learning/propositional/test_simple_graph_1.py
@@ -16,7 +16,6 @@ def test_1():
     model.add_facts({"A": TRUE})
     model.add_facts({"B": FALSE})
     model.train(epochs=11, losses={"contradiction": 1})
-    model.print(params=True)
 
     weights_and = model["A&B"].params("weights")[1]
     weights_or, bias_or = model["A|B"].params("weights", "bias")
@@ -29,7 +28,10 @@ def test_1():
     ), f"expected input B in A&B to be downweighted, received {weights_and}"
     assert bounds is FALSE, f"expected bounds to remain False, received {bounds}"
 
+    return model
+
 
 if __name__ == "__main__":
-    test_1()
+    model = test_1()
+    model.print(params=True)
     print("success")

--- a/tests/learning/propositional/test_supervised_1.py
+++ b/tests/learning/propositional/test_supervised_1.py
@@ -45,10 +45,6 @@ def test_1():
         parameter_history=parameter_history,
     )
 
-    model.print(params=True)
-    plot_params(model)
-    plot_loss(total_loss, losses)
-
     state = model["A|B"].state()
     eps = 1e-3
     assert state is FALSE, f"expected A|B to be FALSE, received {state}"
@@ -71,7 +67,12 @@ def test_1():
         (0 <= w) + (w <= eps)
     ), f"expected A->B weights to be in [0, .5], received {w}"
 
+    return model, total_loss, losses
+
 
 if __name__ == "__main__":
-    test_1()
+    model, total_loss, losses = test_1()
+    model.print(params=True)
+    plot_params(model)
+    plot_loss(total_loss, losses)
     print("success")

--- a/tests/reasoning/logic/propositional/test_api_syntax.py
+++ b/tests/reasoning/logic/propositional/test_api_syntax.py
@@ -23,5 +23,13 @@ def test():
     model.add_formulae(formula)
     model.add_facts(facts)
     model.infer()
-    model.print()
+
     assert model["Friends"].state() == TRUE, "Not friends :-("
+
+    return model
+
+
+if __name__ == "__main__":
+    model = test()
+    model.print()
+    print("success")

--- a/tests/reasoning/logic/propositional/test_bool_and_0.py
+++ b/tests/reasoning/logic/propositional/test_bool_and_0.py
@@ -33,13 +33,13 @@ def test_upward():
     parameter_history = {"weights": True, "bias": True}
     total_loss, _ = model.train(losses=losses, parameter_history=parameter_history)
 
-    # evaluation
+    return model, total_loss, losses
+
+
+if __name__ == "__main__":
+    model, total_loss, losses = test_upward()
     model.print(params=True)
     plot_params(model)
     plot_loss(total_loss, losses)
     print(total_loss[0][-1])
-
-
-if __name__ == "__main__":
-    test_upward()
     print("success")

--- a/tests/reasoning/logic/propositional/test_rv_and_n.py
+++ b/tests/reasoning/logic/propositional/test_rv_and_n.py
@@ -8,7 +8,7 @@ import numpy as np
 from lnn import Proposition, And, Model, Fact
 
 
-def test_upward():
+def test_upward(output=False):
     """standard upward n-input conjunction boolean truth table"""
 
     n = 1000
@@ -21,7 +21,9 @@ def test_upward():
     GT = dat[0]
     for i in range(1, n):
         GT = max(0, GT + dat[i] - 1)
-    print("Ground truth", GT)
+
+    if output:
+        print("Ground truth", GT)
 
     # load model and reason over facts
     facts = {}
@@ -45,7 +47,7 @@ def test_upward():
     model.flush()
 
 
-def test_downward():
+def test_downward(output=False):
     n = 1000
     propositions = list()
     for i in range(0, n):
@@ -56,7 +58,9 @@ def test_downward():
     GT = dat[0]
     for i in range(1, n):
         GT = max(0, GT + dat[i] - 1)
-    print("Ground truth", GT)
+
+    if output:
+        print("Ground truth", GT)
 
     # load model and reason over facts
     facts = {}
@@ -109,6 +113,6 @@ def test_downward():
 
 
 if __name__ == "__main__":
-    test_upward()
-    test_downward()
+    test_upward(output=True)
+    test_downward(output=True)
     print("success")

--- a/tests/reasoning/logic/propositional/test_rv_or_n.py
+++ b/tests/reasoning/logic/propositional/test_rv_or_n.py
@@ -8,7 +8,7 @@ import numpy as np
 from lnn import Proposition, Or, Model, Fact
 
 
-def test_upward():
+def test_upward(output=False):
     """standard upward n-input disjunction boolean truth table"""
 
     n = 1000
@@ -21,7 +21,9 @@ def test_upward():
     GT = dat[0]
     for i in range(1, n):
         GT = min(1, GT + dat[i])
-    print("Ground truth:", GT)
+
+    if output:
+        print("Ground truth:", GT)
 
     # load model and reason over facts
     facts = {}
@@ -45,7 +47,7 @@ def test_upward():
     model.flush()
 
 
-def test_downward():
+def test_downward(output=False):
     n = 1000
     propositions = list()
     for i in range(0, n):
@@ -56,7 +58,9 @@ def test_downward():
     GT = dat[0]
     for i in range(1, n):
         GT = min(1, GT + dat[i])
-    print("Ground truth", GT)
+
+    if output:
+        print("Ground truth", GT)
 
     # load model and reason over facts
     facts = {}
@@ -109,6 +113,6 @@ def test_downward():
 
 
 if __name__ == "__main__":
-    test_upward()
-    test_downward()
+    test_upward(output=True)
+    test_downward(output=True)
     print("success")

--- a/tests/reasoning/logic/propositional/test_simple.py
+++ b/tests/reasoning/logic/propositional/test_simple.py
@@ -45,9 +45,6 @@ def test_1():
         losses=losses,
         parameter_history={"weights": True, "bias": True},
     )
-    model.print(params=True)
-    plot_params(model)
-    plot_loss(total_loss, losses)
 
     A_and_B_weights = model["AB"].params("weights")
     assert A_and_B_weights[1] <= 0.5, (
@@ -57,3 +54,13 @@ def test_1():
     assert all(A_or_B_weights > 0.99), (
         "expected weights at A or B to remain high, " f"received {A_or_B_weights}"
     )
+
+    return model, total_loss, losses
+
+
+if __name__ == "__main__":
+    model, total_loss, losses = test_1()
+    model.print(params=True)
+    plot_params(model)
+    plot_loss(total_loss, losses)
+    print("success")


### PR DESCRIPTION
Some of the tests produce unnecessary output/plots. These are now disabled during `pytest` command and works only during executing test directly via `python test_*.py`.