### PR TITLE
FIX, ADD: kwds catchall for Negation node

### DIFF
--- a/lnn/symbolic/logic.py
+++ b/lnn/symbolic/logic.py
@@ -1312,7 +1312,7 @@ class Not(_UnaryOperator):
             None, _utils.negate_bounds(self.operand.get_facts(*groundings))
         )
 
-    def downward(self) -> torch.Tensor:
+    def downward(self, **kwds) -> torch.Tensor:
         if self.propositional:
             groundings = {None}
         else:


### PR DESCRIPTION
Passing kwds through a negation (as in the learning case) breaks inference - adding a catchall so that the node can ignore unused inputs
solves #26

May need a better mechanism for handling the abstraction of `traverse_execute` but this should suffice for now.