### PR TITLE
ADD: links to papers and blogs

### DIFF
--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx_copybutton",
     "myst_parser",
     "sphinx_material",
+    "sphinx.ext.autosectionlabel",
 ]
 
 html_sidebars = {"**": ["globaltoc.html", "localtoc.html", "searchbox.html"]}

--- a/docsrc/source/education/blogs/blogs.rst
+++ b/docsrc/source/education/blogs/blogs.rst
@@ -1,6 +1,16 @@
 Understanding LNNs
 ==================
 
+You can find many of our blog posts on Medium:
+
+* `Logical Neural Networks <https://skirmilitor.medium.com/logical-neural-networks-31498d1aa9be>`_
+* `NSQA: Neuro-Symbolic Question Answering <https://towardsdatascience.com/nsqa-neuro-symbolic-question-answering-6d14d98e88f3>`_
+* `Getting AI to Reason: Using Logical Neural Networks for Knowledge-Based Question Answering <https://medium.com/swlh/getting-ai-to-reason-using-logical-neural-networks-for-knowledge-based-question-answering-60456654f5fa>`_
+* `Semantic Parsing using Abstract Meaning Representation <https://medium.com/@sroukos/semantic-parsing-using-abstract-meaning-representation-95242518a380>`_
+* `A Semantic Parsing-based Relation Linking approach for Knowledge Base Question Answering <https://medium.com/@sroukos/a-semantic-parsing-based-relation-linking-approach-for-knowledge-base-question-answering-93c14d7931c1>`_
+
+Below are blog posts internal to the LNN repo:
+
 .. toctree::
    :maxdepth: 1
 

--- a/docsrc/source/papers.md
+++ b/docsrc/source/papers.md
@@ -2,47 +2,50 @@
 
 ## Logical Neural Networks
 
-- Ryan Riegel, Alexander Gray, Francois Luus, Naweed Khan, Ndivhuwo Makondo, Ismail Yunus Akhalwaya, 
-Haifeng Qian, Ronald Fagin, Francisco Barahona, Udit Sharma, Shajith Ikbal, Hima Karanam, 
-Sumit Neelam, Ankita Likhyani, Santosh Srivastava, 
-[Logical Neural Network](https://arxiv.org/abs/2006.13155), arXiv, 2020.
-- Ronald Fagin, Ryan Riegel, Alexander Gray, 
-[Foundations of Reasoning with Uncertainty via Real-valued Logics](https://arxiv.org/abs/2008.02429), arXiv, 2020.
-- Lu, Songtao, Naweed Khan, Ismail Yunus Akhalwaya, Ryan Riegel, 
-Lior Horesh, and Alexander Gray, 
-[Training Logical Neural Networks by Primal–Dual Methods for Neuro-Symbolic Reasoning](https://ieeexplore.ieee.org/document/9415044),  
-In ICASSP 2021-2021 IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP), pp. 5559-5563. IEEE, 2021.
-- Thabang Lebese, Ndivhuwo Makondo, Cristina Cornelio and Naweed Khan, 
-[Proof Extraction for Logical Neural Networks](https://openreview.net/forum?id=Xw3kb6UyA31), 
-NeurIPS 2021 workshop on Advances in Programming Languages and Neurosymbolic Systems (AIPLANS)
+- Ryan Riegel, Alexander Gray, Francois Luus, Naweed Khan, Ndivhuwo Makondo, Ismail Yunus Akhalwaya,
+  Haifeng Qian, Ronald Fagin, Francisco Barahona, Udit Sharma, Shajith Ikbal, Hima Karanam,
+  Sumit Neelam, Ankita Likhyani, Santosh Srivastava,
+  [Logical Neural Network](https://arxiv.org/abs/2006.13155), arXiv, 2020.
+- Ronald Fagin, Ryan Riegel, Alexander Gray,
+  [Foundations of Reasoning with Uncertainty via Real-valued Logics](https://arxiv.org/abs/2008.02429), arXiv, 2020.
+- Lu, Songtao, Naweed Khan, Ismail Yunus Akhalwaya, Ryan Riegel,
+  Lior Horesh, and Alexander Gray,
+  [Training Logical Neural Networks by Primal–Dual Methods for Neuro-Symbolic Reasoning](https://ieeexplore.ieee.org/document/9415044),  
+  In ICASSP 2021-2021 IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP), pp. 5559-5563. IEEE, 2021.
+- Thabang Lebese, Ndivhuwo Makondo, Cristina Cornelio and Naweed Khan,
+  [Proof Extraction for Logical Neural Networks](https://openreview.net/forum?id=Xw3kb6UyA31),
+  NeurIPS 2021 workshop on Advances in Programming Languages and Neurosymbolic Systems (AIPLANS)
+- Aidan Evans, Jorge Blanco,
+  [Extending Logical Neural Networks using First-Order Theories](https://arxiv.org/abs/2207.02978), arXiv, 2022.
+
 ## Papers using LNN
 
-- Subhajit Chaudhury, Prithviraj Sen, Masaki Ono, Daiki Kimura, Michiaki Tatsubori, Asim Munawar, 
-[Neuro-Symbolic Approaches for Text-Based Policy Learning](https://aclanthology.org/2021.emnlp-main.245/), 
-Proceedings of the 2021 Conference on Empirical Methods in Natural Language Processing. [Code](https://github.com/subhajit1411/slate-text-based-rl)
-- Daiki Kimura, Masaki Ono, Subhajit Chaudhury, Ryosuke Kohita, Akifumi Wachi, 
-Don Joven Agravante, Michiaki Tatsubori, Asim Munawar, Alexander Gray, 
-[Neuro-Symbolic Reinforcement Learning with First-Order Logic](https://aclanthology.org/2021.emnlp-main.283/), 
-Proceedings of the 2021 Conference on Empirical Methods in Natural Language Processing.
-- Daiki Kimura, Subhajit Chaudhury, Masaki Ono, Michiaki Tatsubori, Don Joven Agravante, 
-Asim Munawar, Akifumi Wachi, Ryosuke Kohita, Alexander Gray, 
-[LOA: Logical Optimal Actions for Text-based Interaction Games](https://aclanthology.org/2021.acl-demo.27/), 
-Proceedings of the 59th Annual Meeting of the Association for Computational Linguistics and the 11th International 
-Joint Conference on Natural Language Processing: System Demonstrations. [Code](https://github.com/ibm/loa), [Demo](https://ibm.biz/acl21-loa)
-- Daiki Kimura, Subhajit Chaudhury, Akifumi Wachi, Ryosuke Kohita, Asim Munawar, 
-Michiaki Tatsubori, Alexander Gray, 
-[Reinforcement Learning with External Knowledge by using Logical Neural Networks](https://arxiv.org/abs/2103.02363), 
-KBRL Workshop at IJCAI-PRICAI 2020.
-- Hang Jiang, Sairam Gurajada, Qiuhao Lu, Sumit Neelam, Lucian Popa, Prithviraj Sen, 
-Yunyao Li, Alexander Gray, [LNN-EL: A Neuro-Symbolic Approach to Short-text Entity Linking](https://aclanthology.org/2021.acl-long.64/), 
-Proceedings of the 59th Annual Meeting of the Association for Computational Linguistics and the 11th International Joint Conference on Natural Language Processing (Volume 1: Long Papers).
-- Pavan Kapanipathi, Ibrahim Abdelaziz, Srinivas Ravishankar, Salim Roukos, Alexander Gray, 
-Ramón Fernandez Astudillo, Maria Chang, Cristina Cornelio, Saswati Dana, Achille Fokoue, 
-Dinesh Garg, Alfio Gliozzo, Sairam Gurajada, Hima Karanam, Naweed Khan, Dinesh Khandelwal, 
-Young-Suk Lee, Yunyao Li, Francois Luus, Ndivhuwo Makondo, Nandana Mihindukulasooriya, 
-Tahira Naseem, Sumit Neelam, Lucian Popa, Revanth Gangi Reddy, Ryan Riegel, 
-Gaetano Rossiello, Udit Sharma, G P Shrivatsa Bhargav, Mo Yu, 
-[Leveraging Abstract Meaning Representation for Knowledge Base Question Answering](https://aclanthology.org/2021.findings-acl.339/), 
-Findings of the Association for Computational Linguistics: ACL-IJCNLP 2021.
+- Subhajit Chaudhury, Prithviraj Sen, Masaki Ono, Daiki Kimura, Michiaki Tatsubori, Asim Munawar,
+  [Neuro-Symbolic Approaches for Text-Based Policy Learning](https://aclanthology.org/2021.emnlp-main.245/),
+  Proceedings of the 2021 Conference on Empirical Methods in Natural Language Processing. [Code](https://github.com/subhajit1411/slate-text-based-rl)
+- Daiki Kimura, Masaki Ono, Subhajit Chaudhury, Ryosuke Kohita, Akifumi Wachi,
+  Don Joven Agravante, Michiaki Tatsubori, Asim Munawar, Alexander Gray,
+  [Neuro-Symbolic Reinforcement Learning with First-Order Logic](https://aclanthology.org/2021.emnlp-main.283/),
+  Proceedings of the 2021 Conference on Empirical Methods in Natural Language Processing.
+- Daiki Kimura, Subhajit Chaudhury, Masaki Ono, Michiaki Tatsubori, Don Joven Agravante,
+  Asim Munawar, Akifumi Wachi, Ryosuke Kohita, Alexander Gray,
+  [LOA: Logical Optimal Actions for Text-based Interaction Games](https://aclanthology.org/2021.acl-demo.27/),
+  Proceedings of the 59th Annual Meeting of the Association for Computational Linguistics and the 11th International
+  Joint Conference on Natural Language Processing: System Demonstrations. [Code](https://github.com/ibm/loa), [Demo](https://ibm.biz/acl21-loa)
+- Daiki Kimura, Subhajit Chaudhury, Akifumi Wachi, Ryosuke Kohita, Asim Munawar,
+  Michiaki Tatsubori, Alexander Gray,
+  [Reinforcement Learning with External Knowledge by using Logical Neural Networks](https://arxiv.org/abs/2103.02363),
+  KBRL Workshop at IJCAI-PRICAI 2020.
+- Hang Jiang, Sairam Gurajada, Qiuhao Lu, Sumit Neelam, Lucian Popa, Prithviraj Sen,
+  Yunyao Li, Alexander Gray, [LNN-EL: A Neuro-Symbolic Approach to Short-text Entity Linking](https://aclanthology.org/2021.acl-long.64/),
+  Proceedings of the 59th Annual Meeting of the Association for Computational Linguistics and the 11th International Joint Conference on Natural Language Processing (Volume 1: Long Papers).
+- Pavan Kapanipathi, Ibrahim Abdelaziz, Srinivas Ravishankar, Salim Roukos, Alexander Gray,
+  Ramón Fernandez Astudillo, Maria Chang, Cristina Cornelio, Saswati Dana, Achille Fokoue,
+  Dinesh Garg, Alfio Gliozzo, Sairam Gurajada, Hima Karanam, Naweed Khan, Dinesh Khandelwal,
+  Young-Suk Lee, Yunyao Li, Francois Luus, Ndivhuwo Makondo, Nandana Mihindukulasooriya,
+  Tahira Naseem, Sumit Neelam, Lucian Popa, Revanth Gangi Reddy, Ryan Riegel,
+  Gaetano Rossiello, Udit Sharma, G P Shrivatsa Bhargav, Mo Yu,
+  [Leveraging Abstract Meaning Representation for Knowledge Base Question Answering](https://aclanthology.org/2021.findings-acl.339/),
+  Findings of the Association for Computational Linguistics: ACL-IJCNLP 2021.
 - Francois Luus, Prithviraj Sen, Pavan Kapanipathi, Ryan Riegel, Ndivhuwo Makondo, Thabang Lebese, Alexander Gray
-[Logic Embeddings for Complex Query Answering](https://arxiv.org/abs/2103.00418), arXiv, 2021.
+  [Logic Embeddings for Complex Query Answering](https://arxiv.org/abs/2103.00418), arXiv, 2021.


### PR DESCRIPTION
Signed-off-by: mattfaltyn <mattfaltyn@Matts-MacBook-Pro.local>

Added links to 5 Medium posts related to LNNs and a link to the recently published "Extending Logical Neural Networks using First-Order Theories" preprint. 