### PR TITLE
FIX: Not downward operator and operands bounds sometimes doesn't match

### DIFF
--- a/lnn/symbolic/logic/unary_operator.py
+++ b/lnn/symbolic/logic/unary_operator.py
@@ -329,8 +329,10 @@ class Not(_UnaryOperator):
                 for g in groundings:
                     if g not in self.operands[0]._groundings:
                         self.operands[0]._add_groundings(g)
+
+            table_rows = list(self.operands[0].grounding_table.get(self._ground(g)) for g in groundings) 
             bounds = self.operands[0].neuron.aggregate_bounds(
-                None, _utils.negate_bounds(self.get_data(*groundings))
+                table_rows, _utils.negate_bounds(self.get_data(*groundings))
             )
             if self.operands[0].is_contradiction():
                 logging.info(


### PR DESCRIPTION
In my program, #1 and #2 genenrates different results due to different order of data. It's caused by not passing grouding_rows to bounds_aggregate function in Not downward.
#1
model.add_data(
    {
        fourleg: {"D1": lnn.Fact.TRUE},
        twoleg: {"A1": lnn.Fact.TRUE, "B1":lnn.Fact.TRUE},
    }
)

#2
model.add_data(
    {
        twoleg: {"A1": lnn.Fact.TRUE, "B1":lnn.Fact.TRUE},
        fourleg: {"D1": lnn.Fact.TRUE},    
    }
)