### PR TITLE
Add support for filtering invalid groundings out

### DIFF
--- a/lnn/symbolic/_gm.py
+++ b/lnn/symbolic/_gm.py
@@ -152,6 +152,8 @@ def _operational_bounds(
         joined = operand_dfs[0]
     else:
         joined = ft.reduce(_full_outer_join, operand_dfs)
+        if hasattr(operator, 'filter_valid_groundings'):
+            joined = operator.filter_valid_groundings(joined)
 
     operator_groundings = _operator_groundings(joined, operator)
     ground_objects = _operand_groundings(joined, operator, bindings)


### PR DESCRIPTION
As you already know, doing outer join on constants produces many groundings which might be semantically invalid or impossible. This increases the size of the grounding table unnecessarily which in turn impacts performance drastically. To reduce search space, a proper solution might be to allow non-primitive types to be used in place of constants and then, to do type checking. Maybe you have plans for fixing this in a better way. However, here is a small change that makes this possible at least for some applications, in the meantime.

This PR allows developers to define their own neurons or formula (possibly inherited from LNN classes) and add a `filter_valid_groundings` method which takes the data frame of all potential groundings and returns another data frame in place. Thus they have the opportunity to filter out incompatible groundings.