### PR TITLE
Add stale issue and PR management

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: 🐛 Bug Report
+description: Report a critical bug in LNN
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## ⚠️ Repository Status
+        
+        **This repository is archived and in maintenance mode.**
+        
+        We are only accepting:
+        - 🔒 Security fixes
+        - 🐛 Critical bug fixes  
+        - 📝 Documentation corrections
+        
+        Other feature requests and enhancements will not be reviewed.
+        
+        ---
+        
+  - type: checkboxes
+    id: issue-type
+    attributes:
+      label: Issue Type
+      description: Please confirm this is one of the accepted types
+      options:
+        - label: This is a security vulnerability
+        - label: This is a critical bug that prevents basic functionality
+        - label: This is a documentation error
+          
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug
+      placeholder: What happened?
+    validations:
+      required: true
+      
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Import lnn
+        2. Run example code
+        3. See error
+    validations:
+      required: true
+      
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+      placeholder: It should...
+    validations:
+      required: true
+      
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Your environment details
+      value: |
+        - Python version:
+        - LNN version:
+        - Operating System:
+        - torch version:
+        - numpy version:
+    validations:
+      required: true
+      
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem
+      placeholder: Stack traces, screenshots, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 General Questions
+    url: https://github.com/IBM/LNN/discussions
+    about: For general questions, please use GitHub Discussions
+  - name: 📚 Documentation
+    url: https://ibm.github.io/LNN/introduction.html
+    about: Read the full documentation
+  - name: ⚠️ Repository Archived
+    url: https://github.com/IBM/LNN
+    about: This repository is archived. Only security/critical bugs are accepted.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,54 @@
+name: 📝 Documentation Fix
+description: Report a documentation error or typo
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📝 Documentation Fix
+        
+        **This repository is archived and in maintenance mode.**
+        
+        We accept documentation corrections and clarifications.
+        
+        ---
+        
+  - type: textarea
+    id: location
+    attributes:
+      label: Documentation Location
+      description: Where is the documentation error?
+      placeholder: |
+        File: README.md
+        Line: 42
+        Section: Installation
+    validations:
+      required: true
+      
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Documentation
+      description: What does the documentation currently say?
+      placeholder: Paste the incorrect text
+    validations:
+      required: true
+      
+  - type: textarea
+    id: correct
+    attributes:
+      label: Suggested Correction
+      description: What should it say instead?
+      placeholder: Paste the corrected text
+    validations:
+      required: true
+      
+  - type: textarea
+    id: why
+    attributes:
+      label: Why This Change
+      description: Explain why this is incorrect
+      placeholder: This is wrong because...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,76 @@
+name: 🔒 Security Vulnerability
+description: Report a security vulnerability (reviewed with priority)
+title: "[Security]: "
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 🔒 Security Report
+        
+        Thank you for helping keep LNN secure!
+        
+        **This repository is archived but we actively maintain security.**
+        
+        Security reports are reviewed with **HIGH PRIORITY**.
+        
+        ---
+        
+  - type: textarea
+    id: vulnerability
+    attributes:
+      label: Vulnerability Description
+      description: Describe the security vulnerability
+      placeholder: What is the security issue?
+    validations:
+      required: true
+      
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this vulnerability?
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+      
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What is the potential impact?
+      placeholder: What could an attacker do?
+    validations:
+      required: true
+      
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: How to reproduce the vulnerability
+      placeholder: |
+        1. Set up environment
+        2. Run exploit code
+        3. Observe vulnerability
+    validations:
+      required: true
+      
+  - type: textarea
+    id: affected
+    attributes:
+      label: Affected Versions
+      description: Which versions are affected?
+      placeholder: All versions / v1.0+ / etc.
+    validations:
+      required: true
+      
+  - type: textarea
+    id: cve
+    attributes:
+      label: CVE or Advisory
+      description: Is there an existing CVE or security advisory?
+      placeholder: CVE-2024-XXXXX or link to advisory

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,70 @@
+name: Stale Issue and PR Management
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale issues and PRs
+        uses: actions/stale@v9
+        with:
+          # Stale issue configuration
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,security,bug,enhancement'
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity in the past 90 days.
+            
+            **Note:** This repository is archived and in maintenance mode. We are only accepting:
+            - Security fixes
+            - Critical bug fixes
+            - Documentation corrections
+            
+            If this issue is still relevant, please comment to keep it open. Otherwise, it will be closed in 14 days.
+            
+            Thank you for your contributions to LNN!
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity.
+            
+            If you believe this issue should remain open, please reopen it with updated information or context.
+            
+            As this repository is archived, we are only maintaining security and critical fixes.
+          
+          # Stale PR configuration  
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'pinned,security,work-in-progress'
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity in the past 60 days.
+            
+            **Note:** This repository is archived and in maintenance mode. We are only accepting:
+            - Security fixes
+            - Critical bug fixes
+            - Documentation corrections
+            
+            Please update this PR if it addresses one of the above categories. Otherwise, it will be closed in 14 days.
+            
+            Thank you for your contribution!
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+            
+            If this PR addresses a security issue or critical bug, please reopen it with updated information.
+          
+          # Operations configuration
+          operations-per-run: 30
+          remove-stale-when-updated: true
+          ascending: false # Process newest first
+          
+          # Debugging
+          debug-only: false


### PR DESCRIPTION
## Summary

Adds automated stale issue/PR management for the archived repository.

## Changes

### Stale Workflow
- Auto-marks issues stale after 90 days of inactivity
- Closes stale issues after 14 additional days  
- Auto-marks PRs stale after 60 days of inactivity
- Exempts security, bug, enhancement, and pinned labels
- Custom messages explaining archived repository status
- Manual trigger option via workflow_dispatch

### Issue Templates
- **Bug Report**: Structured template with archived repo warning
- **Security Vulnerability**: High-priority security reporting
- **Documentation Fix**: For documentation corrections
- **Config**: Contact links and repo status notice

## Benefits

- Automatically manages stale issues reducing manual work
- Sets clear expectations that repo is archived
- Prioritizes security issues appropriately
- Guides contributors with structured forms
- Reduces maintenance burden

## Testing

- Workflow syntax validated
- Templates follow GitHub issue forms spec

## Next Steps

After merge:
- Workflow runs daily at 00:00 UTC
- Can manually trigger: Actions → Stale Management → Run workflow
- New issues will show templates with archived notice